### PR TITLE
Include Benchmarks Groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The scraped data is stored in a JSON file (`benchmarks_data.json`) in this repos
 
 *   Scrapes all available benchmark links from the main Vals.ai benchmarks page.
 *   Visits each benchmark page to extract detailed model data.
+*   Uses Selenium to dynamically load and capture all available benchmark entries on each page, ensuring comprehensive data collection beyond initial view limits.
 *   Parses Model Name, Company (from SVG icon filename), Accuracy, Cost Input, Cost Output, and Latency for each model.
 *   Stores the collected data in a structured JSON format.
 *   Includes a timestamp for when the data was last updated.
@@ -91,6 +92,10 @@ This chart aggregates data by provider, showing average costs across different b
 https://analytics.zoho.com/open-view/2732937000006459493
 This chart provides a detailed view of individual model performance and costs per benchmark.
 
+### LLM Performance Grouped by Benchmarks
+https://analytics.zoho.com/open-view/2732937000006462636
+This chart groups the data by the benchmark categories themselves (e.g., Legal QA, Coding, Reasoning), allowing comparison of how models perform on average within specific domains.
+
 ### Chart Filters and Cost Explanation
 
 Both embedded charts offer interactive filters to refine the data being displayed:
@@ -112,4 +117,4 @@ Contributing
 Contributions are welcome! If you find issues or have suggestions for improvements (e.g., adding more data points, improving parsing robustness), please open an issue or submit a pull request.
 License
 
-This project is licensed under the MIT License - see the LICENSE file for details.
+This project is licensed under the MIT License.

--- a/benchmarks_data.json
+++ b/benchmarks_data.json
@@ -1,6 +1,786 @@
 {
-    "timestamp_utc": "2025-06-16 01:13:48",
+    "timestamp_utc": "2025-06-16 01:20:48",
     "benchmarks": [
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "o3 Mini",
+            "company": "Openai",
+            "accuracy": 86.5,
+            "cost_input": "$1.10",
+            "cost_output": "$4.40",
+            "latency": 154.65
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Gemini 2.5 Pro Exp",
+            "company": "Google",
+            "accuracy": 85.8,
+            "cost_input": "$1.25",
+            "cost_output": "$10.00",
+            "latency": 143.91
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "o3",
+            "company": "Openai",
+            "accuracy": 85.3,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 266.18
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Grok 3 Mini Fast High Reasoning",
+            "company": "xAI",
+            "accuracy": 85.0,
+            "cost_input": "$0.60",
+            "cost_output": "$4.00",
+            "latency": 102.25
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Qwen 3 (235B)",
+            "company": "Alibaba",
+            "accuracy": 84.0,
+            "cost_input": "$0.22",
+            "cost_output": "$0.88",
+            "latency": 242.17
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "o4 Mini",
+            "company": "Openai",
+            "accuracy": 83.7,
+            "cost_input": "$1.10",
+            "cost_output": "$4.40",
+            "latency": 55.11
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Claude Sonnet 4 (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 76.3,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 271.79
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "DeepSeek R1",
+            "company": "Deepseek",
+            "accuracy": 74.0,
+            "cost_input": "$8.00",
+            "cost_output": "$8.00",
+            "latency": 153.91
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "o1",
+            "company": "Openai",
+            "accuracy": 71.5,
+            "cost_input": "$15.00",
+            "cost_output": "$60.00",
+            "latency": 177.03
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Grok 3 Mini Fast Low Reasoning",
+            "company": "xAI",
+            "accuracy": 70.6,
+            "cost_input": "$0.60",
+            "cost_output": "$4.00",
+            "latency": 31.4
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Grok 3 Beta",
+            "company": "xAI",
+            "accuracy": 58.7,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 63.99
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "DeepSeek V3 (03/24/2025)",
+            "company": "Deepseek",
+            "accuracy": 52.2,
+            "cost_input": "$1.20",
+            "cost_output": "$1.20",
+            "latency": 50.57
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "GPT 4.1 Mini",
+            "company": "Openai",
+            "accuracy": 49.4,
+            "cost_input": "$0.40",
+            "cost_output": "$1.60",
+            "latency": 33.14
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Claude 3.7 Sonnet (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 44.6,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 303.71
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Mistral Medium 3.1 (05/2025)",
+            "company": "Mistral",
+            "accuracy": 42.3,
+            "cost_input": "$0.40",
+            "cost_output": "$2.00",
+            "latency": 65.95
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Claude Opus 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 41.3,
+            "cost_input": "$15.00",
+            "cost_output": "$75.00",
+            "latency": 37.03
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "GPT 4.1",
+            "company": "Openai",
+            "accuracy": 39.8,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 161.08
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Claude Sonnet 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 38.5,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 23.4
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Gemini 2.0 Flash (001)",
+            "company": "Google",
+            "accuracy": 29.8,
+            "cost_input": "$0.10",
+            "cost_output": "$0.40",
+            "latency": 11.21
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "DeepSeek V3",
+            "company": "Deepseek",
+            "accuracy": 27.5,
+            "cost_input": "$0.90",
+            "cost_output": "$0.90",
+            "latency": 58.8
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "GPT 4.1 Nano",
+            "company": "Openai",
+            "accuracy": 27.3,
+            "cost_input": "$0.10",
+            "cost_output": "$0.40",
+            "latency": 11.91
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Llama 4 Maverick",
+            "company": "Meta",
+            "accuracy": 25.2,
+            "cost_input": "$0.27",
+            "cost_output": "$0.85",
+            "latency": 15.5
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Claude 3.7 Sonnet (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 22.3,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 18.93
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Llama 4 Scout",
+            "company": "Meta",
+            "accuracy": 19.0,
+            "cost_input": "$0.18",
+            "cost_output": "$0.59",
+            "latency": 21.69
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Gemini 1.5 Pro (002)",
+            "company": "Google",
+            "accuracy": 18.7,
+            "cost_input": "$1.25",
+            "cost_output": "$5.00",
+            "latency": 10.64
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Gemini 1.5 Flash (002)",
+            "company": "Google",
+            "accuracy": 17.3,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 5.7
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Llama 3.3 Instruct Turbo (70B)",
+            "company": "Meta",
+            "accuracy": 16.0,
+            "cost_input": "$0.88",
+            "cost_output": "$0.88",
+            "latency": 11.24
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Grok 2",
+            "company": "xAI",
+            "accuracy": 15.2,
+            "cost_input": "$2.00",
+            "cost_output": "$10.00",
+            "latency": 57.88
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "GPT 4o (2024-08-06)",
+            "company": "Openai",
+            "accuracy": 14.0,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 68.37
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Command A",
+            "company": "Cohere",
+            "accuracy": 13.3,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 23.35
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "GPT 4o (2024-11-20)",
+            "company": "Openai",
+            "accuracy": 11.9,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 15.78
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "GPT 4o Mini",
+            "company": "Openai",
+            "accuracy": 11.5,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": 28.77
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Claude 3.5 Sonnet Latest",
+            "company": "Anthropic",
+            "accuracy": 10.0,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 9.19
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Mistral Large (11/2024)",
+            "company": "Mistral",
+            "accuracy": 9.2,
+            "cost_input": "$2.00",
+            "cost_output": "$6.00",
+            "latency": 19.68
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Mistral Small (02/2024)",
+            "company": "Mistral",
+            "accuracy": 5.6,
+            "cost_input": "$0.20",
+            "cost_output": "$0.60",
+            "latency": 13.23
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Mistral Small 3.1 (03/2025)",
+            "company": "Mistral",
+            "accuracy": 3.5,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 11.68
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Claude 3.5 Haiku Latest",
+            "company": "Anthropic",
+            "accuracy": 3.3,
+            "cost_input": "$1.00",
+            "cost_output": "$5.00",
+            "latency": 9.05
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Jamba 1.6 Large",
+            "company": "Ai21 Labs",
+            "accuracy": 0.4,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 18.86
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Jamba 1.6 Mini",
+            "company": "Ai21 Labs",
+            "accuracy": 0.4,
+            "cost_input": "$0.20",
+            "cost_output": "$0.40",
+            "latency": 6.62
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4.1",
+            "company": "Openai",
+            "accuracy": 71.2,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 10.33
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "o3",
+            "company": "Openai",
+            "accuracy": 71.0,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 19.13
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "o4 Mini",
+            "company": "Openai",
+            "accuracy": 70.1,
+            "cost_input": "$1.10",
+            "cost_output": "$4.40",
+            "latency": 17.5
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Grok 3 Beta",
+            "company": "xAI",
+            "accuracy": 69.1,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 23.86
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Grok 3 Mini Fast High Reasoning",
+            "company": "xAI",
+            "accuracy": 68.6,
+            "cost_input": "$0.60",
+            "cost_output": "$4.00",
+            "latency": 14.12
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 2.5 Pro Exp",
+            "company": "Google",
+            "accuracy": 68.4,
+            "cost_input": "$1.25",
+            "cost_output": "$10.00",
+            "latency": 17.99
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Claude 3.7 Sonnet (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 68.0,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 22.33
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Claude Sonnet 4 (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 67.3,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 227.37
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Grok 3 Mini Fast Low Reasoning",
+            "company": "xAI",
+            "accuracy": 66.0,
+            "cost_input": "$0.60",
+            "cost_output": "$4.00",
+            "latency": 10.42
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4.1 Mini",
+            "company": "Openai",
+            "accuracy": 65.8,
+            "cost_input": "$0.40",
+            "cost_output": "$1.60",
+            "latency": 6.56
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "DeepSeek R1",
+            "company": "Deepseek",
+            "accuracy": 63.2,
+            "cost_input": "$8.00",
+            "cost_output": "$8.00",
+            "latency": 46.8
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 2.5 Flash Preview (Nonthinking)",
+            "company": "Google",
+            "accuracy": 62.6,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": 8.67
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "DeepSeek V3 (03/24/2025)",
+            "company": "Deepseek",
+            "accuracy": 60.9,
+            "cost_input": "$1.20",
+            "cost_output": "$1.20",
+            "latency": 36.59
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "DeepSeek V3",
+            "company": "Deepseek",
+            "accuracy": 60.7,
+            "cost_input": "$0.90",
+            "cost_output": "$0.90",
+            "latency": 28.88
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Claude 3.5 Sonnet Latest",
+            "company": "Anthropic",
+            "accuracy": 60.5,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": null
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Claude Sonnet 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 59.9,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 162.67
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Claude 3.5 Haiku Latest",
+            "company": "Anthropic",
+            "accuracy": 58.2,
+            "cost_input": "$1.00",
+            "cost_output": "$5.00",
+            "latency": null
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Grok 2",
+            "company": "xAI",
+            "accuracy": 58.2,
+            "cost_input": "$2.00",
+            "cost_output": "$10.00",
+            "latency": 84.8
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Mistral Medium 3.1 (05/2025)",
+            "company": "Mistral",
+            "accuracy": 58.1,
+            "cost_input": "$0.40",
+            "cost_output": "$2.00",
+            "latency": 30.56
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Llama 4 Maverick",
+            "company": "Meta",
+            "accuracy": 57.6,
+            "cost_input": "$0.27",
+            "cost_output": "$0.85",
+            "latency": 6.59
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4o (2024-11-20)",
+            "company": "Openai",
+            "accuracy": 56.6,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 6.35
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "o3 Mini",
+            "company": "Openai",
+            "accuracy": 55.7,
+            "cost_input": "$1.10",
+            "cost_output": "$4.40",
+            "latency": 31.42
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4o Mini",
+            "company": "Openai",
+            "accuracy": 55.0,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": null
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Command A",
+            "company": "Cohere",
+            "accuracy": 54.5,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 14.34
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Llama 4 Scout",
+            "company": "Meta",
+            "accuracy": 53.9,
+            "cost_input": "$0.18",
+            "cost_output": "$0.59",
+            "latency": 9.22
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Mistral Small 3.1 (03/2025)",
+            "company": "Mistral",
+            "accuracy": 53.2,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 12.25
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 2.0 Pro Exp",
+            "company": "Google",
+            "accuracy": 53.1,
+            "cost_input": "$1.25",
+            "cost_output": "$5.00",
+            "latency": 18.13
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4.1 Nano",
+            "company": "Openai",
+            "accuracy": 52.4,
+            "cost_input": "$0.10",
+            "cost_output": "$0.40",
+            "latency": 12.47
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Jamba 1.6 Large",
+            "company": "Ai21 Labs",
+            "accuracy": 50.7,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 29.61
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 1.5 Pro (002)",
+            "company": "Google",
+            "accuracy": 50.3,
+            "cost_input": "$1.25",
+            "cost_output": "$5.00",
+            "latency": 37.35
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4o (2024-08-06)",
+            "company": "Openai",
+            "accuracy": 49.3,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": null
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Llama 3.1 Instruct Turbo (70B)",
+            "company": "Meta",
+            "accuracy": 47.2,
+            "cost_input": "$0.88",
+            "cost_output": "$0.88",
+            "latency": null
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Jamba 1.5 Large",
+            "company": "Ai21 Labs",
+            "accuracy": 46.6,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 10.74
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 1.5 Flash (002)",
+            "company": "Google",
+            "accuracy": 46.6,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 28.38
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Jamba 1.6 Mini",
+            "company": "Ai21 Labs",
+            "accuracy": 46.0,
+            "cost_input": "$0.20",
+            "cost_output": "$0.40",
+            "latency": 4.28
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Llama 3.1 Instruct Turbo (8B)",
+            "company": "Meta",
+            "accuracy": 43.5,
+            "cost_input": "$0.18",
+            "cost_output": "$0.18",
+            "latency": null
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Jamba 1.5 Mini",
+            "company": "Ai21 Labs",
+            "accuracy": 39.9,
+            "cost_input": "$0.20",
+            "cost_output": "$0.40",
+            "latency": 2.34
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 2.0 Flash (001)",
+            "company": "Google",
+            "accuracy": 38.5,
+            "cost_input": "$0.10",
+            "cost_output": "$0.40",
+            "latency": 31.35
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 1.5 Flash (001)",
+            "company": "Google",
+            "accuracy": 32.9,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": null
+        },
         {
             "benchmark": "math500-05-30-2025",
             "benchmark_group": "Math",
@@ -452,634 +1232,404 @@
             "latency": 4.86
         },
         {
-            "benchmark": "finance_agent",
-            "benchmark_group": "Finance",
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
             "model": "o3",
             "company": "Openai",
-            "accuracy": 48.3,
-            "cost_input": "$0.74",
-            "cost_output": "N/A",
-            "latency": 180.18
+            "accuracy": 83.6,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 65.78
         },
         {
-            "benchmark": "finance_agent",
-            "benchmark_group": "Finance",
-            "model": "Claude Sonnet 4 (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 44.5,
-            "cost_input": "$0.85",
-            "cost_output": "N/A",
-            "latency": 136.75
-        },
-        {
-            "benchmark": "finance_agent",
-            "benchmark_group": "Finance",
-            "model": "Claude 3.7 Sonnet (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 44.1,
-            "cost_input": "$1.05",
-            "cost_output": "N/A",
-            "latency": 156.21
-        },
-        {
-            "benchmark": "finance_agent",
-            "benchmark_group": "Finance",
-            "model": "Claude Sonnet 4 (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 43.5,
-            "cost_input": "$0.89",
-            "cost_output": "N/A",
-            "latency": 105.2
-        },
-        {
-            "benchmark": "finance_agent",
-            "benchmark_group": "Finance",
-            "model": "Claude 3.7 Sonnet (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 42.9,
-            "cost_input": "$0.99",
-            "cost_output": "N/A",
-            "latency": 124.6
-        },
-        {
-            "benchmark": "finance_agent",
-            "benchmark_group": "Finance",
-            "model": "o4 Mini",
-            "company": "Openai",
-            "accuracy": 36.5,
-            "cost_input": "$0.28",
-            "cost_output": "N/A",
-            "latency": 162.14
-        },
-        {
-            "benchmark": "finance_agent",
-            "benchmark_group": "Finance",
-            "model": "Grok 3 Mini Fast High Reasoning",
-            "company": "xAI",
-            "accuracy": 31.7,
-            "cost_input": "$0.13",
-            "cost_output": "N/A",
-            "latency": 270.68
-        },
-        {
-            "benchmark": "finance_agent",
-            "benchmark_group": "Finance",
-            "model": "Gemini 2.5 Pro Preview",
-            "company": "Google",
-            "accuracy": 29.4,
-            "cost_input": "$0.22",
-            "cost_output": "N/A",
-            "latency": 80.21
-        },
-        {
-            "benchmark": "finance_agent",
-            "benchmark_group": "Finance",
-            "model": "GPT 4.1",
-            "company": "Openai",
-            "accuracy": 24.6,
-            "cost_input": "$0.24",
-            "cost_output": "N/A",
-            "latency": 66.47
-        },
-        {
-            "benchmark": "finance_agent",
-            "benchmark_group": "Finance",
-            "model": "Grok 3 Beta",
-            "company": "xAI",
-            "accuracy": 24.1,
-            "cost_input": "$0.44",
-            "cost_output": "N/A",
-            "latency": 64.48
-        },
-        {
-            "benchmark": "finance_agent",
-            "benchmark_group": "Finance",
-            "model": "GPT 4.1 Mini",
-            "company": "Openai",
-            "accuracy": 20.8,
-            "cost_input": "$0.07",
-            "cost_output": "N/A",
-            "latency": 50.11
-        },
-        {
-            "benchmark": "finance_agent",
-            "benchmark_group": "Finance",
-            "model": "o1",
-            "company": "Openai",
-            "accuracy": 20.8,
-            "cost_input": "$1.44",
-            "cost_output": "N/A",
-            "latency": 421.83
-        },
-        {
-            "benchmark": "finance_agent",
-            "benchmark_group": "Finance",
-            "model": "GPT 4o (2024-08-06)",
-            "company": "Openai",
-            "accuracy": 19.3,
-            "cost_input": "$0.26",
-            "cost_output": "N/A",
-            "latency": 43.41
-        },
-        {
-            "benchmark": "finance_agent",
-            "benchmark_group": "Finance",
-            "model": "Grok 3 Mini Fast Low Reasoning",
-            "company": "xAI",
-            "accuracy": 17.1,
-            "cost_input": "$0.07",
-            "cost_output": "N/A",
-            "latency": 79.49
-        },
-        {
-            "benchmark": "finance_agent",
-            "benchmark_group": "Finance",
-            "model": "Claude 3.5 Haiku Latest",
-            "company": "Anthropic",
-            "accuracy": 14.3,
-            "cost_input": "$0.07",
-            "cost_output": "N/A",
-            "latency": 46.6
-        },
-        {
-            "benchmark": "finance_agent",
-            "benchmark_group": "Finance",
-            "model": "Gemini 2.0 Flash (001)",
-            "company": "Google",
-            "accuracy": 13.2,
-            "cost_input": "$0.01",
-            "cost_output": "N/A",
-            "latency": 26.16
-        },
-        {
-            "benchmark": "finance_agent",
-            "benchmark_group": "Finance",
-            "model": "o3 Mini",
-            "company": "Openai",
-            "accuracy": 12.7,
-            "cost_input": "$0.04",
-            "cost_output": "N/A",
-            "latency": 146.86
-        },
-        {
-            "benchmark": "finance_agent",
-            "benchmark_group": "Finance",
-            "model": "GPT 4o Mini",
-            "company": "Openai",
-            "accuracy": 10.8,
-            "cost_input": "$0.04",
-            "cost_output": "N/A",
-            "latency": 96.03
-        },
-        {
-            "benchmark": "finance_agent",
-            "benchmark_group": "Finance",
-            "model": "Mistral Small 3.1 (03/2025)",
-            "company": "Mistral",
-            "accuracy": 10.0,
-            "cost_input": "$0.01",
-            "cost_output": "N/A",
-            "latency": 44.56
-        },
-        {
-            "benchmark": "finance_agent",
-            "benchmark_group": "Finance",
-            "model": "Command A",
-            "company": "Cohere",
-            "accuracy": 4.3,
-            "cost_input": "$0.58",
-            "cost_output": "N/A",
-            "latency": 100.95
-        },
-        {
-            "benchmark": "finance_agent",
-            "benchmark_group": "Finance",
-            "model": "Llama 4 Maverick",
-            "company": "Meta",
-            "accuracy": 3.6,
-            "cost_input": "$0.00",
-            "cost_output": "N/A",
-            "latency": 10.21
-        },
-        {
-            "benchmark": "finance_agent",
-            "benchmark_group": "Finance",
-            "model": "Llama 3.3 Instruct Turbo (70B)",
-            "company": "Meta",
-            "accuracy": 3.4,
-            "cost_input": "$0.00",
-            "cost_output": "N/A",
-            "latency": 3.5
-        },
-        {
-            "benchmark": "finance_agent",
-            "benchmark_group": "Finance",
-            "model": "GPT 4.1 Nano",
-            "company": "Openai",
-            "accuracy": 2.5,
-            "cost_input": "$0.00",
-            "cost_output": "N/A",
-            "latency": 63.48
-        },
-        {
-            "benchmark": "finance_agent",
-            "benchmark_group": "Finance",
-            "model": "Jamba 1.6 Mini",
-            "company": "Ai21 Labs",
-            "accuracy": 1.7,
-            "cost_input": "$0.04",
-            "cost_output": "N/A",
-            "latency": 36.01
-        },
-        {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
-            "model": "o3 Mini",
-            "company": "Openai",
-            "accuracy": 86.5,
-            "cost_input": "$1.10",
-            "cost_output": "$4.40",
-            "latency": 154.65
-        },
-        {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
             "model": "Gemini 2.5 Pro Exp",
             "company": "Google",
-            "accuracy": 85.8,
+            "accuracy": 80.3,
             "cost_input": "$1.25",
             "cost_output": "$10.00",
-            "latency": 143.91
+            "latency": 41.1
         },
         {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
-            "model": "o3",
-            "company": "Openai",
-            "accuracy": 85.3,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 266.18
-        },
-        {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
             "model": "Grok 3 Mini Fast High Reasoning",
             "company": "xAI",
-            "accuracy": 85.0,
+            "accuracy": 79.0,
             "cost_input": "$0.60",
             "cost_output": "$4.00",
-            "latency": 102.25
+            "latency": 40.62
         },
         {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
-            "model": "Qwen 3 (235B)",
-            "company": "Alibaba",
-            "accuracy": 84.0,
-            "cost_input": "$0.22",
-            "cost_output": "$0.88",
-            "latency": 242.17
-        },
-        {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
-            "model": "o4 Mini",
-            "company": "Openai",
-            "accuracy": 83.7,
-            "cost_input": "$1.10",
-            "cost_output": "$4.40",
-            "latency": 55.11
-        },
-        {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
-            "model": "Claude Sonnet 4 (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 76.3,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 271.79
-        },
-        {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
-            "model": "DeepSeek R1",
-            "company": "Deepseek",
-            "accuracy": 74.0,
-            "cost_input": "$8.00",
-            "cost_output": "$8.00",
-            "latency": 153.91
-        },
-        {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
-            "model": "o1",
-            "company": "Openai",
-            "accuracy": 71.5,
-            "cost_input": "$15.00",
-            "cost_output": "$60.00",
-            "latency": 177.03
-        },
-        {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
-            "model": "Grok 3 Mini Fast Low Reasoning",
-            "company": "xAI",
-            "accuracy": 70.6,
-            "cost_input": "$0.60",
-            "cost_output": "$4.00",
-            "latency": 31.4
-        },
-        {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
-            "model": "Grok 3 Beta",
-            "company": "xAI",
-            "accuracy": 58.7,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 63.99
-        },
-        {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
-            "model": "DeepSeek V3 (03/24/2025)",
-            "company": "Deepseek",
-            "accuracy": 52.2,
-            "cost_input": "$1.20",
-            "cost_output": "$1.20",
-            "latency": 50.57
-        },
-        {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
-            "model": "GPT 4.1 Mini",
-            "company": "Openai",
-            "accuracy": 49.4,
-            "cost_input": "$0.40",
-            "cost_output": "$1.60",
-            "latency": 33.14
-        },
-        {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
             "model": "Claude 3.7 Sonnet (Thinking)",
             "company": "Anthropic",
-            "accuracy": 44.6,
+            "accuracy": 75.3,
             "cost_input": "$3.00",
             "cost_output": "$15.00",
-            "latency": 303.71
+            "latency": 155.02
         },
         {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
-            "model": "Mistral Medium 3.1 (05/2025)",
-            "company": "Mistral",
-            "accuracy": 42.3,
-            "cost_input": "$0.40",
-            "cost_output": "$2.00",
-            "latency": 65.95
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "o3 Mini",
+            "company": "Openai",
+            "accuracy": 75.0,
+            "cost_input": "$1.10",
+            "cost_output": "$4.40",
+            "latency": 99.98
         },
         {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "o4 Mini",
+            "company": "Openai",
+            "accuracy": 74.5,
+            "cost_input": "$1.10",
+            "cost_output": "$4.40",
+            "latency": 30.0
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Claude Sonnet 4 (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 74.5,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 118.46
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Grok 3 Beta",
+            "company": "xAI",
+            "accuracy": 73.7,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 29.91
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "o1",
+            "company": "Openai",
+            "accuracy": 73.0,
+            "cost_input": "$15.00",
+            "cost_output": "$60.00",
+            "latency": 40.18
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Grok 3 Mini Fast Low Reasoning",
+            "company": "xAI",
+            "accuracy": 72.7,
+            "cost_input": "$0.60",
+            "cost_output": "$4.00",
+            "latency": 14.23
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
             "model": "Claude Opus 4 (Nonthinking)",
             "company": "Anthropic",
-            "accuracy": 41.3,
+            "accuracy": 71.7,
             "cost_input": "$15.00",
             "cost_output": "$75.00",
-            "latency": 37.03
+            "latency": 19.13
         },
         {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
-            "model": "GPT 4.1",
-            "company": "Openai",
-            "accuracy": 39.8,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 161.08
-        },
-        {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
             "model": "Claude Sonnet 4 (Nonthinking)",
             "company": "Anthropic",
-            "accuracy": 38.5,
+            "accuracy": 69.4,
             "cost_input": "$3.00",
             "cost_output": "$15.00",
-            "latency": 23.4
+            "latency": 12.82
         },
         {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
-            "model": "Gemini 2.0 Flash (001)",
-            "company": "Google",
-            "accuracy": 29.8,
-            "cost_input": "$0.10",
-            "cost_output": "$0.40",
-            "latency": 11.21
-        },
-        {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
-            "model": "DeepSeek V3",
-            "company": "Deepseek",
-            "accuracy": 27.5,
-            "cost_input": "$0.90",
-            "cost_output": "$0.90",
-            "latency": 58.8
-        },
-        {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
-            "model": "GPT 4.1 Nano",
-            "company": "Openai",
-            "accuracy": 27.3,
-            "cost_input": "$0.10",
-            "cost_output": "$0.40",
-            "latency": 11.91
-        },
-        {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
             "model": "Llama 4 Maverick",
             "company": "Meta",
-            "accuracy": 25.2,
+            "accuracy": 67.7,
             "cost_input": "$0.27",
             "cost_output": "$0.85",
-            "latency": 15.5
+            "latency": 10.07
         },
         {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
             "model": "Claude 3.7 Sonnet (Nonthinking)",
             "company": "Anthropic",
-            "accuracy": 22.3,
+            "accuracy": 67.4,
             "cost_input": "$3.00",
             "cost_output": "$15.00",
-            "latency": 18.93
+            "latency": 9.22
         },
         {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
-            "model": "Llama 4 Scout",
-            "company": "Meta",
-            "accuracy": 19.0,
-            "cost_input": "$0.18",
-            "cost_output": "$0.59",
-            "latency": 21.69
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "GPT 4.1 Mini",
+            "company": "Openai",
+            "accuracy": 67.4,
+            "cost_input": "$0.40",
+            "cost_output": "$1.60",
+            "latency": 9.28
         },
         {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
-            "model": "Gemini 1.5 Pro (002)",
-            "company": "Google",
-            "accuracy": 18.7,
-            "cost_input": "$1.25",
-            "cost_output": "$5.00",
-            "latency": 10.64
-        },
-        {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
-            "model": "Gemini 1.5 Flash (002)",
-            "company": "Google",
-            "accuracy": 17.3,
-            "cost_input": "$0.07",
-            "cost_output": "$0.30",
-            "latency": 5.7
-        },
-        {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
-            "model": "Llama 3.3 Instruct Turbo (70B)",
-            "company": "Meta",
-            "accuracy": 16.0,
-            "cost_input": "$0.88",
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Qwen 3 (235B)",
+            "company": "Alibaba",
+            "accuracy": 66.4,
+            "cost_input": "$0.22",
             "cost_output": "$0.88",
-            "latency": 11.24
+            "latency": 306.22
         },
         {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
-            "model": "Grok 2",
-            "company": "xAI",
-            "accuracy": 15.2,
-            "cost_input": "$2.00",
-            "cost_output": "$10.00",
-            "latency": 57.88
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Gemini 2.0 Flash (001)",
+            "company": "Google",
+            "accuracy": 65.2,
+            "cost_input": "$0.10",
+            "cost_output": "$0.40",
+            "latency": 5.8
         },
         {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
-            "model": "GPT 4o (2024-08-06)",
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "GPT 4.1",
             "company": "Openai",
-            "accuracy": 14.0,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 68.37
-        },
-        {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
-            "model": "Command A",
-            "company": "Cohere",
-            "accuracy": 13.3,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 23.35
-        },
-        {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
-            "model": "GPT 4o (2024-11-20)",
-            "company": "Openai",
-            "accuracy": 11.9,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 15.78
-        },
-        {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
-            "model": "GPT 4o Mini",
-            "company": "Openai",
-            "accuracy": 11.5,
-            "cost_input": "$0.15",
-            "cost_output": "$0.60",
-            "latency": 28.77
-        },
-        {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
-            "model": "Claude 3.5 Sonnet Latest",
-            "company": "Anthropic",
-            "accuracy": 10.0,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 9.19
-        },
-        {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
-            "model": "Mistral Large (11/2024)",
-            "company": "Mistral",
-            "accuracy": 9.2,
-            "cost_input": "$2.00",
-            "cost_output": "$6.00",
-            "latency": 19.68
-        },
-        {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
-            "model": "Mistral Small (02/2024)",
-            "company": "Mistral",
-            "accuracy": 5.6,
-            "cost_input": "$0.20",
-            "cost_output": "$0.60",
-            "latency": 13.23
-        },
-        {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
-            "model": "Mistral Small 3.1 (03/2025)",
-            "company": "Mistral",
-            "accuracy": 3.5,
-            "cost_input": "$0.07",
-            "cost_output": "$0.30",
-            "latency": 11.68
-        },
-        {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
-            "model": "Claude 3.5 Haiku Latest",
-            "company": "Anthropic",
-            "accuracy": 3.3,
-            "cost_input": "$1.00",
-            "cost_output": "$5.00",
-            "latency": 9.05
-        },
-        {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
-            "model": "Jamba 1.6 Large",
-            "company": "Ai21 Labs",
-            "accuracy": 0.4,
+            "accuracy": 64.6,
             "cost_input": "$2.00",
             "cost_output": "$8.00",
-            "latency": 18.86
+            "latency": 23.14
         },
         {
-            "benchmark": "aime-2025-05-30",
-            "benchmark_group": "Math",
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "DeepSeek V3 (03/24/2025)",
+            "company": "Deepseek",
+            "accuracy": 61.1,
+            "cost_input": "$1.20",
+            "cost_output": "$1.20",
+            "latency": 23.48
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Claude 3.5 Sonnet Latest",
+            "company": "Anthropic",
+            "accuracy": 59.1,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 7.24
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Gemini 1.5 Pro (002)",
+            "company": "Google",
+            "accuracy": 58.3,
+            "cost_input": "$1.25",
+            "cost_output": "$5.00",
+            "latency": 7.71
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "DeepSeek V3",
+            "company": "Deepseek",
+            "accuracy": 54.0,
+            "cost_input": "$0.90",
+            "cost_output": "$0.90",
+            "latency": 21.28
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Gemini 2.5 Flash Preview (Nonthinking)",
+            "company": "Google",
+            "accuracy": 53.3,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": 43.45
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "GPT 4o (2024-11-20)",
+            "company": "Openai",
+            "accuracy": 53.0,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 14.92
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Mistral Small (02/2024)",
+            "company": "Mistral",
+            "accuracy": 50.8,
+            "cost_input": "$0.20",
+            "cost_output": "$0.60",
+            "latency": 7.99
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "GPT 4o (2024-05-13)",
+            "company": "Openai",
+            "accuracy": 50.3,
+            "cost_input": "$5.00",
+            "cost_output": "$15.00",
+            "latency": 10.08
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Llama 3.3 Instruct Turbo (70B)",
+            "company": "Meta",
+            "accuracy": 50.0,
+            "cost_input": "$0.88",
+            "cost_output": "$0.88",
+            "latency": 7.34
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Grok 2",
+            "company": "xAI",
+            "accuracy": 50.0,
+            "cost_input": "$2.00",
+            "cost_output": "$10.00",
+            "latency": 20.18
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Gemini 1.5 Flash (002)",
+            "company": "Google",
+            "accuracy": 46.0,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 3.39
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Mistral Large (11/2024)",
+            "company": "Mistral",
+            "accuracy": 45.2,
+            "cost_input": "$2.00",
+            "cost_output": "$6.00",
+            "latency": 15.8
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Llama 4 Scout",
+            "company": "Meta",
+            "accuracy": 44.4,
+            "cost_input": "$0.18",
+            "cost_output": "$0.59",
+            "latency": 12.09
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "GPT 4o Mini",
+            "company": "Openai",
+            "accuracy": 44.2,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": 15.32
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Mistral Small 3.1 (03/2025)",
+            "company": "Mistral",
+            "accuracy": 41.4,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 8.82
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "GPT 4.1 Nano",
+            "company": "Openai",
+            "accuracy": 39.9,
+            "cost_input": "$0.10",
+            "cost_output": "$0.40",
+            "latency": 4.19
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Claude 3.5 Haiku Latest",
+            "company": "Anthropic",
+            "accuracy": 37.9,
+            "cost_input": "$1.00",
+            "cost_output": "$5.00",
+            "latency": 6.56
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "GPT 3.5",
+            "company": "Openai",
+            "accuracy": 29.3,
+            "cost_input": "$0.50",
+            "cost_output": "$1.50",
+            "latency": 2.63
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Command A",
+            "company": "Cohere",
+            "accuracy": 29.3,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 11.49
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Command R+",
+            "company": "Cohere",
+            "accuracy": 29.0,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 8.19
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Jamba 1.6 Large",
+            "company": "Ai21 Labs",
+            "accuracy": 24.2,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 15.47
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
             "model": "Jamba 1.6 Mini",
             "company": "Ai21 Labs",
-            "accuracy": 0.4,
+            "accuracy": 20.5,
             "cost_input": "$0.20",
             "cost_output": "$0.40",
-            "latency": 6.62
+            "latency": 4.95
         },
         {
             "benchmark": "mmlu_pro-05-30-2025",
@@ -1482,1626 +2032,6 @@
             "latency": 2.43
         },
         {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Gemini 2.5 Pro Exp",
-            "company": "Google",
-            "accuracy": 83.6,
-            "cost_input": "$1.25",
-            "cost_output": "$10.00",
-            "latency": 3.51
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Gemini 2.5 Flash Preview (Nonthinking)",
-            "company": "Google",
-            "accuracy": 82.8,
-            "cost_input": "$0.15",
-            "cost_output": "$0.60",
-            "latency": 0.43
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "o3",
-            "company": "Openai",
-            "accuracy": 82.5,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 5.14
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Grok 3 Mini Fast High Reasoning",
-            "company": "xAI",
-            "accuracy": 82.0,
-            "cost_input": "$0.60",
-            "cost_output": "$4.00",
-            "latency": 4.92
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Grok 3 Beta",
-            "company": "xAI",
-            "accuracy": 82.0,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 0.44
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "GPT 4.1",
-            "company": "Openai",
-            "accuracy": 81.9,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 0.42
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Gemini 2.5 Flash Preview (Thinking)",
-            "company": "Google",
-            "accuracy": 81.8,
-            "cost_input": "$0.15",
-            "cost_output": "$3.50",
-            "latency": 2.66
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "o1 Preview",
-            "company": "Openai",
-            "accuracy": 81.7,
-            "cost_input": "$15.00",
-            "cost_output": "$60.00",
-            "latency": 10.33
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Grok 3 Mini Fast Low Reasoning",
-            "company": "xAI",
-            "accuracy": 81.6,
-            "cost_input": "$0.60",
-            "cost_output": "$4.00",
-            "latency": 3.38
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Claude Opus 4 (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 81.6,
-            "cost_input": "$15.00",
-            "cost_output": "$75.00",
-            "latency": 3.39
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Claude Sonnet 4 (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 81.5,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 4.68
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Claude Sonnet 4 (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 81.3,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 10.79
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "DeepSeek V3",
-            "company": "Deepseek",
-            "accuracy": 80.1,
-            "cost_input": "$0.90",
-            "cost_output": "$0.90",
-            "latency": 4.13
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "DeepSeek V3 (03/24/2025)",
-            "company": "Deepseek",
-            "accuracy": 79.9,
-            "cost_input": "$1.20",
-            "cost_output": "$1.20",
-            "latency": 7.33
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "GPT 4o (2024-11-20)",
-            "company": "Openai",
-            "accuracy": 79.8,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 0.35
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Gemini 2.0 Flash (001)",
-            "company": "Google",
-            "accuracy": 79.7,
-            "cost_input": "$0.10",
-            "cost_output": "$0.40",
-            "latency": 0.34
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Claude 3.7 Sonnet (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 79.3,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 6.6
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Qwen 2.5 Instruct Turbo (72B)",
-            "company": "Alibaba",
-            "accuracy": 79.2,
-            "cost_input": "$1.20",
-            "cost_output": "$1.20",
-            "latency": 0.62
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Qwen 3 (235B)",
-            "company": "Alibaba",
-            "accuracy": 79.2,
-            "cost_input": "$0.22",
-            "cost_output": "$0.88",
-            "latency": 11.58
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "o4 Mini",
-            "company": "Openai",
-            "accuracy": 79.0,
-            "cost_input": "$1.10",
-            "cost_output": "$4.40",
-            "latency": 3.66
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Llama 3.1 Instruct Turbo (405B)",
-            "company": "Meta",
-            "accuracy": 79.0,
-            "cost_input": "$3.50",
-            "cost_output": "$3.50",
-            "latency": 0.81
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "GPT 4o (2024-08-06)",
-            "company": "Openai",
-            "accuracy": 79.0,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 0.39
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Claude 3.5 Sonnet Latest",
-            "company": "Anthropic",
-            "accuracy": 78.8,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 0.83
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Command A",
-            "company": "Cohere",
-            "accuracy": 78.7,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 0.71
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "o1 Mini",
-            "company": "Openai",
-            "accuracy": 78.7,
-            "cost_input": "$3.00",
-            "cost_output": "$12.00",
-            "latency": 3.81
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Llama 3.1 Instruct Turbo (70B)",
-            "company": "Meta",
-            "accuracy": 78.2,
-            "cost_input": "$0.88",
-            "cost_output": "$0.88",
-            "latency": 3.01
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Claude 3.7 Sonnet (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 78.1,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 1.13
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Llama 3.3 Instruct Turbo (70B)",
-            "company": "Meta",
-            "accuracy": 78.0,
-            "cost_input": "$0.88",
-            "cost_output": "$0.88",
-            "latency": 0.56
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "GPT 4 Turbo",
-            "company": "Openai",
-            "accuracy": 78.0,
-            "cost_input": "$10.00",
-            "cost_output": "$30.00",
-            "latency": 1.01
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Claude 3.5 Sonnet",
-            "company": "Anthropic",
-            "accuracy": 77.6,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 1.4
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "o1",
-            "company": "Openai",
-            "accuracy": 77.6,
-            "cost_input": "$15.00",
-            "cost_output": "$60.00",
-            "latency": 8.47
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Claude 3 Opus",
-            "company": "Anthropic",
-            "accuracy": 77.5,
-            "cost_input": "$15.00",
-            "cost_output": "$75.00",
-            "latency": 4.61
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Llama 4 Maverick",
-            "company": "Meta",
-            "accuracy": 77.2,
-            "cost_input": "$0.27",
-            "cost_output": "$0.85",
-            "latency": 0.28
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "GPT 4.1 Mini",
-            "company": "Openai",
-            "accuracy": 76.8,
-            "cost_input": "$0.40",
-            "cost_output": "$1.60",
-            "latency": 0.41
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "GPT 4o Mini",
-            "company": "Openai",
-            "accuracy": 76.2,
-            "cost_input": "$0.15",
-            "cost_output": "$0.60",
-            "latency": 0.4
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Jamba 1.5 Large",
-            "company": "Ai21 Labs",
-            "accuracy": 74.8,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 0.73
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Gemini 1.5 Pro (001)",
-            "company": "Google",
-            "accuracy": 74.4,
-            "cost_input": "$1.25",
-            "cost_output": "$5.00",
-            "latency": 1.54
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Jamba 1.6 Large",
-            "company": "Ai21 Labs",
-            "accuracy": 74.1,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 0.65
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Gemini 1.0 Pro 002",
-            "company": "Google",
-            "accuracy": 73.4,
-            "cost_input": "$0.50",
-            "cost_output": "$1.50",
-            "latency": 0.44
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Claude 3.5 Haiku Latest",
-            "company": "Anthropic",
-            "accuracy": 73.0,
-            "cost_input": "$1.00",
-            "cost_output": "$5.00",
-            "latency": 1.0
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Qwen 2.5 Instruct Turbo (7B)",
-            "company": "Alibaba",
-            "accuracy": 72.4,
-            "cost_input": "$0.30",
-            "cost_output": "$0.30",
-            "latency": 0.33
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Claude 3 Sonnet",
-            "company": "Anthropic",
-            "accuracy": 72.3,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 1.98
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Llama 4 Scout",
-            "company": "Meta",
-            "accuracy": 71.8,
-            "cost_input": "$0.18",
-            "cost_output": "$0.59",
-            "latency": 0.23
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Gemini 1.5 Pro (002)",
-            "company": "Google",
-            "accuracy": 71.6,
-            "cost_input": "$1.25",
-            "cost_output": "$5.00",
-            "latency": 0.62
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Mistral Small 3.1 (03/2025)",
-            "company": "Mistral",
-            "accuracy": 70.9,
-            "cost_input": "$0.07",
-            "cost_output": "$0.30",
-            "latency": 0.41
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "o3 Mini",
-            "company": "Openai",
-            "accuracy": 70.9,
-            "cost_input": "$1.10",
-            "cost_output": "$4.40",
-            "latency": 9.8
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Command R+",
-            "company": "Cohere",
-            "accuracy": 70.5,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 0.27
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Gemma 2 (9B)",
-            "company": "Google",
-            "accuracy": 70.0,
-            "cost_input": "$0.20",
-            "cost_output": "$0.20",
-            "latency": 0.43
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "DeepSeek R1",
-            "company": "Deepseek",
-            "accuracy": 69.9,
-            "cost_input": "$8.00",
-            "cost_output": "$8.00",
-            "latency": 18.66
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Jamba 1.6 Mini",
-            "company": "Ai21 Labs",
-            "accuracy": 69.7,
-            "cost_input": "$0.20",
-            "cost_output": "$0.40",
-            "latency": 0.27
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Command",
-            "company": "Cohere",
-            "accuracy": 68.8,
-            "cost_input": "$1.00",
-            "cost_output": "$2.00",
-            "latency": 2.0
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Jamba 1.5 Mini",
-            "company": "Ai21 Labs",
-            "accuracy": 68.1,
-            "cost_input": "$0.20",
-            "cost_output": "$0.40",
-            "latency": 0.25
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Gemma 2 (27B)",
-            "company": "Google",
-            "accuracy": 65.5,
-            "cost_input": "$0.50",
-            "cost_output": "$0.50",
-            "latency": 0.59
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "GPT 3.5",
-            "company": "Openai",
-            "accuracy": 64.8,
-            "cost_input": "$0.50",
-            "cost_output": "$1.50",
-            "latency": 0.48
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Gemini 1.5 Flash (002)",
-            "company": "Google",
-            "accuracy": 62.0,
-            "cost_input": "$0.07",
-            "cost_output": "$0.30",
-            "latency": 0.41
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Mistral Medium 3.1 (05/2025)",
-            "company": "Mistral",
-            "accuracy": 61.3,
-            "cost_input": "$0.40",
-            "cost_output": "$2.00",
-            "latency": 0.43
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Llama 2 (70B)",
-            "company": "Meta",
-            "accuracy": 59.4,
-            "cost_input": "$0.90",
-            "cost_output": "$0.90",
-            "latency": 13.08
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "GPT 4.1 Nano",
-            "company": "Openai",
-            "accuracy": 58.3,
-            "cost_input": "$0.10",
-            "cost_output": "$0.40",
-            "latency": 0.34
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Mixtral (8x7B)",
-            "company": "Mistral",
-            "accuracy": 53.3,
-            "cost_input": "$0.60",
-            "cost_output": "$0.60",
-            "latency": 13.81
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Llama 3.1 Instruct Turbo (8B)",
-            "company": "Meta",
-            "accuracy": 52.5,
-            "cost_input": "$0.18",
-            "cost_output": "$0.18",
-            "latency": 0.56
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Llama 2 (13B)",
-            "company": "Meta",
-            "accuracy": 51.6,
-            "cost_input": "$0.20",
-            "cost_output": "$0.20",
-            "latency": 1.35
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Mistral (7B)",
-            "company": "Mistral",
-            "accuracy": 51.0,
-            "cost_input": "$0.18",
-            "cost_output": "$0.18",
-            "latency": 1.95
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Falcon (40B)",
-            "company": "Technology Innovation Institute",
-            "accuracy": 50.9,
-            "cost_input": "$0.80",
-            "cost_output": "$0.80",
-            "latency": 5.05
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Llama 2 (7B)",
-            "company": "Meta",
-            "accuracy": 49.3,
-            "cost_input": "$0.20",
-            "cost_output": "$0.20",
-            "latency": 0.85
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Falcon (7B)",
-            "company": "Technology Innovation Institute",
-            "accuracy": 47.1,
-            "cost_input": "$0.20",
-            "cost_output": "$0.20",
-            "latency": 1.24
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "DBRX Instruct",
-            "company": "Databricks",
-            "accuracy": 35.6,
-            "cost_input": "$2.25",
-            "cost_output": "$6.75",
-            "latency": 0.82
-        },
-        {
-            "benchmark": "legal_bench-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Command R",
-            "company": "Cohere",
-            "accuracy": 35.0,
-            "cost_input": "$0.15",
-            "cost_output": "$0.60",
-            "latency": 0.19
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "Gemini 2.5 Pro Exp",
-            "company": "Google",
-            "accuracy": 81.5,
-            "cost_input": "$1.25",
-            "cost_output": "$10.00",
-            "latency": 24.15
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "o3",
-            "company": "Openai",
-            "accuracy": 80.1,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 39.27
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "o4 Mini",
-            "company": "Openai",
-            "accuracy": 79.7,
-            "cost_input": "$1.10",
-            "cost_output": "$4.40",
-            "latency": 19.72
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "o1",
-            "company": "Openai",
-            "accuracy": 77.7,
-            "cost_input": "$15.00",
-            "cost_output": "$60.00",
-            "latency": 26.41
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "Claude 3.7 Sonnet (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 76.0,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 69.58
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "Claude Sonnet 4 (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 75.1,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 48.85
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "Claude Opus 4 (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 73.4,
-            "cost_input": "$15.00",
-            "cost_output": "$75.00",
-            "latency": 14.02
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "Llama 4 Maverick",
-            "company": "Meta",
-            "accuracy": 72.6,
-            "cost_input": "$0.27",
-            "cost_output": "$0.85",
-            "latency": 7.91
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "Claude Sonnet 4 (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 72.6,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 10.82
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "Gemini 2.0 Flash (001)",
-            "company": "Google",
-            "accuracy": 71.9,
-            "cost_input": "$0.10",
-            "cost_output": "$0.40",
-            "latency": 45.22
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "Claude 3.7 Sonnet (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 71.6,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 8.32
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "GPT 4.1 Mini",
-            "company": "Openai",
-            "accuracy": 71.1,
-            "cost_input": "$0.40",
-            "cost_output": "$1.60",
-            "latency": 8.23
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "Claude 3.5 Sonnet Latest",
-            "company": "Anthropic",
-            "accuracy": 68.9,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 46.01
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "GPT 4.1",
-            "company": "Openai",
-            "accuracy": 68.9,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 12.0
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "GPT 4o (2024-11-20)",
-            "company": "Openai",
-            "accuracy": 68.1,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 45.87
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "Grok 2 Vision",
-            "company": "xAI",
-            "accuracy": 66.5,
-            "cost_input": "$2.00",
-            "cost_output": "$10.00",
-            "latency": 18.36
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "Llama 4 Scout",
-            "company": "Meta",
-            "accuracy": 66.5,
-            "cost_input": "$0.18",
-            "cost_output": "$0.59",
-            "latency": 10.51
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "Gemini 1.5 Pro (002)",
-            "company": "Google",
-            "accuracy": 66.1,
-            "cost_input": "$1.25",
-            "cost_output": "$5.00",
-            "latency": 43.73
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "GPT 4o (2024-08-06)",
-            "company": "Openai",
-            "accuracy": 65.5,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 47.53
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "Mistral Medium 3.1 (05/2025)",
-            "company": "Mistral",
-            "accuracy": 63.1,
-            "cost_input": "$0.40",
-            "cost_output": "$2.00",
-            "latency": 12.56
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "Mistral Small 3.1 (03/2025)",
-            "company": "Mistral",
-            "accuracy": 60.6,
-            "cost_input": "$0.07",
-            "cost_output": "$0.30",
-            "latency": 13.4
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "Llama 3.2 Vision (90B)",
-            "company": "Meta",
-            "accuracy": 58.8,
-            "cost_input": "$1.20",
-            "cost_output": "$1.20",
-            "latency": 56.34
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "GPT 4o Mini",
-            "company": "Openai",
-            "accuracy": 58.2,
-            "cost_input": "$0.15",
-            "cost_output": "$0.60",
-            "latency": 45.02
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "Gemini 1.5 Flash (002)",
-            "company": "Google",
-            "accuracy": 57.6,
-            "cost_input": "$0.07",
-            "cost_output": "$0.30",
-            "latency": 41.31
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "GPT 4.1 Nano",
-            "company": "Openai",
-            "accuracy": 55.6,
-            "cost_input": "$0.10",
-            "cost_output": "$0.40",
-            "latency": 7.25
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "Llama 3.2 Vision (11B)",
-            "company": "Meta",
-            "accuracy": 50.3,
-            "cost_input": "$0.18",
-            "cost_output": "$0.18",
-            "latency": 38.07
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Llama 3.1 Instruct Turbo (405B)",
-            "company": "Meta",
-            "accuracy": 75.2,
-            "cost_input": "$3.50",
-            "cost_output": "$3.50",
-            "latency": 2.19
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Claude 3 Opus",
-            "company": "Anthropic",
-            "accuracy": 74.0,
-            "cost_input": "$15.00",
-            "cost_output": "$75.00",
-            "latency": 5.97
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Qwen 2.5 Instruct Turbo (72B)",
-            "company": "Alibaba",
-            "accuracy": 73.6,
-            "cost_input": "$1.20",
-            "cost_output": "$1.20",
-            "latency": 1.01
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Claude 3.7 Sonnet (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 73.0,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 8.87
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "o1 Mini",
-            "company": "Openai",
-            "accuracy": 72.8,
-            "cost_input": "$3.00",
-            "cost_output": "$12.00",
-            "latency": 4.01
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "o1",
-            "company": "Openai",
-            "accuracy": 72.7,
-            "cost_input": "$15.00",
-            "cost_output": "$60.00",
-            "latency": 11.26
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "GPT 4o Mini",
-            "company": "Openai",
-            "accuracy": 72.4,
-            "cost_input": "$0.15",
-            "cost_output": "$0.60",
-            "latency": 1.92
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Claude Sonnet 4 (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 72.4,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 2.91
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "GPT 4 Turbo",
-            "company": "Openai",
-            "accuracy": 71.8,
-            "cost_input": "$10.00",
-            "cost_output": "$30.00",
-            "latency": 3.26
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "GPT 4.1 Mini",
-            "company": "Openai",
-            "accuracy": 71.5,
-            "cost_input": "$0.40",
-            "cost_output": "$1.60",
-            "latency": 1.03
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Grok 3 Mini Fast Low Reasoning",
-            "company": "xAI",
-            "accuracy": 70.8,
-            "cost_input": "$0.60",
-            "cost_output": "$4.00",
-            "latency": 4.92
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Gemini 1.5 Flash (002)",
-            "company": "Google",
-            "accuracy": 70.4,
-            "cost_input": "$0.07",
-            "cost_output": "$0.30",
-            "latency": 0.8
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "o3 Mini",
-            "company": "Openai",
-            "accuracy": 69.3,
-            "cost_input": "$1.10",
-            "cost_output": "$4.40",
-            "latency": 46.24
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "o1 Preview",
-            "company": "Openai",
-            "accuracy": 69.0,
-            "cost_input": "$15.00",
-            "cost_output": "$60.00",
-            "latency": 12.83
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "o4 Mini",
-            "company": "Openai",
-            "accuracy": 68.9,
-            "cost_input": "$1.10",
-            "cost_output": "$4.40",
-            "latency": 4.53
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Claude Opus 4 (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 68.8,
-            "cost_input": "$15.00",
-            "cost_output": "$75.00",
-            "latency": 4.37
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Claude 3.5 Sonnet Latest",
-            "company": "Anthropic",
-            "accuracy": 68.7,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 2.28
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Claude 3.5 Haiku Latest",
-            "company": "Anthropic",
-            "accuracy": 68.7,
-            "cost_input": "$1.00",
-            "cost_output": "$5.00",
-            "latency": 2.88
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Llama 3.1 Instruct Turbo (70B)",
-            "company": "Meta",
-            "accuracy": 68.6,
-            "cost_input": "$0.88",
-            "cost_output": "$0.88",
-            "latency": 4.74
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "GPT 4.1",
-            "company": "Openai",
-            "accuracy": 68.4,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 1.11
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "DeepSeek V3",
-            "company": "Deepseek",
-            "accuracy": 68.4,
-            "cost_input": "$0.90",
-            "cost_output": "$0.90",
-            "latency": 2.15
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Command R+",
-            "company": "Cohere",
-            "accuracy": 68.2,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 1.17
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Claude 3.5 Sonnet",
-            "company": "Anthropic",
-            "accuracy": 68.2,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 1.61
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Claude 3.7 Sonnet (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 68.1,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 2.29
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Gemini 1.5 Pro (001)",
-            "company": "Google",
-            "accuracy": 68.0,
-            "cost_input": "$1.25",
-            "cost_output": "$5.00",
-            "latency": 4.11
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Gemini 1.5 Pro (002)",
-            "company": "Google",
-            "accuracy": 68.0,
-            "cost_input": "$1.25",
-            "cost_output": "$5.00",
-            "latency": 4.11
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "GPT 4o (2024-11-20)",
-            "company": "Openai",
-            "accuracy": 68.0,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 1.03
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Command A",
-            "company": "Cohere",
-            "accuracy": 67.7,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 1.44
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Claude 3 Sonnet",
-            "company": "Anthropic",
-            "accuracy": 67.6,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 3.03
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Mistral Large (11/2024)",
-            "company": "Mistral",
-            "accuracy": 67.0,
-            "cost_input": "$2.00",
-            "cost_output": "$6.00",
-            "latency": 2.16
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Gemini 2.0 Flash (001)",
-            "company": "Google",
-            "accuracy": 66.8,
-            "cost_input": "$0.10",
-            "cost_output": "$0.40",
-            "latency": 0.7
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Llama 3 (70B)",
-            "company": "Meta",
-            "accuracy": 66.8,
-            "cost_input": "$0.90",
-            "cost_output": "$0.90",
-            "latency": 2.92
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Gemini 1.0 Pro 002",
-            "company": "Google",
-            "accuracy": 66.7,
-            "cost_input": "$0.50",
-            "cost_output": "$1.50",
-            "latency": 0.89
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Command R",
-            "company": "Cohere",
-            "accuracy": 66.7,
-            "cost_input": "$0.15",
-            "cost_output": "$0.60",
-            "latency": 0.56
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Mistral Medium 3.1 (05/2025)",
-            "company": "Mistral",
-            "accuracy": 66.2,
-            "cost_input": "$0.40",
-            "cost_output": "$2.00",
-            "latency": 1.99
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Jamba 1.6 Mini",
-            "company": "Ai21 Labs",
-            "accuracy": 66.1,
-            "cost_input": "$0.20",
-            "cost_output": "$0.40",
-            "latency": 0.61
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "o3",
-            "company": "Openai",
-            "accuracy": 66.0,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 6.02
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Llama 3.3 Instruct Turbo (70B)",
-            "company": "Meta",
-            "accuracy": 66.0,
-            "cost_input": "$0.88",
-            "cost_output": "$0.88",
-            "latency": 1.01
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Claude Sonnet 4 (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 66.0,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 10.83
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Mistral Small 3.1 (03/2025)",
-            "company": "Mistral",
-            "accuracy": 65.9,
-            "cost_input": "$0.07",
-            "cost_output": "$0.30",
-            "latency": 1.45
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Mixtral (8x7B)",
-            "company": "Mistral",
-            "accuracy": 64.9,
-            "cost_input": "$0.60",
-            "cost_output": "$0.60",
-            "latency": 1.11
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Gemini 2.5 Pro Exp",
-            "company": "Google",
-            "accuracy": 64.7,
-            "cost_input": "$1.25",
-            "cost_output": "$10.00",
-            "latency": 8.38
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "DeepSeek V3 (03/24/2025)",
-            "company": "Deepseek",
-            "accuracy": 64.7,
-            "cost_input": "$1.20",
-            "cost_output": "$1.20",
-            "latency": 4.22
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Mistral Small (02/2024)",
-            "company": "Mistral",
-            "accuracy": 64.1,
-            "cost_input": "$0.20",
-            "cost_output": "$0.60",
-            "latency": 1.57
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Qwen 3 (235B)",
-            "company": "Alibaba",
-            "accuracy": 63.6,
-            "cost_input": "$0.22",
-            "cost_output": "$0.88",
-            "latency": 17.6
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Grok 3 Beta",
-            "company": "xAI",
-            "accuracy": 63.5,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 0.81
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Gemini 2.5 Flash Preview (Nonthinking)",
-            "company": "Google",
-            "accuracy": 63.4,
-            "cost_input": "$0.15",
-            "cost_output": "$0.60",
-            "latency": 0.82
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Llama 3.1 Instruct Turbo (8B)",
-            "company": "Meta",
-            "accuracy": 63.4,
-            "cost_input": "$0.18",
-            "cost_output": "$0.18",
-            "latency": 0.92
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Grok 3 Mini Fast High Reasoning",
-            "company": "xAI",
-            "accuracy": 63.4,
-            "cost_input": "$0.60",
-            "cost_output": "$4.00",
-            "latency": 7.5
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Llama 4 Maverick",
-            "company": "Meta",
-            "accuracy": 63.3,
-            "cost_input": "$0.27",
-            "cost_output": "$0.85",
-            "latency": 2.24
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Mistral (7B)",
-            "company": "Mistral",
-            "accuracy": 63.0,
-            "cost_input": "$0.18",
-            "cost_output": "$0.18",
-            "latency": 0.87
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Llama 3 (8B)",
-            "company": "Meta",
-            "accuracy": 62.7,
-            "cost_input": "$0.20",
-            "cost_output": "$0.20",
-            "latency": 0.57
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Qwen 2.5 Instruct Turbo (7B)",
-            "company": "Alibaba",
-            "accuracy": 62.6,
-            "cost_input": "$0.30",
-            "cost_output": "$0.30",
-            "latency": 0.78
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "DeepSeek R1",
-            "company": "Deepseek",
-            "accuracy": 62.0,
-            "cost_input": "$8.00",
-            "cost_output": "$8.00",
-            "latency": 30.54
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Jamba 1.5 Large",
-            "company": "Ai21 Labs",
-            "accuracy": 61.9,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 3.15
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Llama 4 Scout",
-            "company": "Meta",
-            "accuracy": 61.8,
-            "cost_input": "$0.18",
-            "cost_output": "$0.59",
-            "latency": 2.14
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "GPT 4o (2024-08-06)",
-            "company": "Openai",
-            "accuracy": 61.7,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 1.32
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "GPT 3.5",
-            "company": "Openai",
-            "accuracy": 61.6,
-            "cost_input": "$0.50",
-            "cost_output": "$1.50",
-            "latency": 1.09
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Jamba 1.6 Large",
-            "company": "Ai21 Labs",
-            "accuracy": 61.2,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 2.54
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Gemini 2.5 Flash Preview (Thinking)",
-            "company": "Google",
-            "accuracy": 60.6,
-            "cost_input": "$0.15",
-            "cost_output": "$3.50",
-            "latency": 5.08
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Gemma 2 (27B)",
-            "company": "Google",
-            "accuracy": 59.9,
-            "cost_input": "$0.50",
-            "cost_output": "$0.50",
-            "latency": 2.21
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Llama 2 (70B)",
-            "company": "Meta",
-            "accuracy": 59.7,
-            "cost_input": "$0.90",
-            "cost_output": "$0.90",
-            "latency": 1.39
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Gemma 2 (9B)",
-            "company": "Google",
-            "accuracy": 59.6,
-            "cost_input": "$0.20",
-            "cost_output": "$0.20",
-            "latency": 0.91
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Grok 2",
-            "company": "xAI",
-            "accuracy": 58.0,
-            "cost_input": "$2.00",
-            "cost_output": "$10.00",
-            "latency": 1.06
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Jamba 1.5 Mini",
-            "company": "Ai21 Labs",
-            "accuracy": 56.2,
-            "cost_input": "$0.20",
-            "cost_output": "$0.40",
-            "latency": 0.52
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Llama 2 (13B)",
-            "company": "Meta",
-            "accuracy": 55.9,
-            "cost_input": "$0.20",
-            "cost_output": "$0.20",
-            "latency": 1.47
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "GPT 4.1 Nano",
-            "company": "Openai",
-            "accuracy": 54.8,
-            "cost_input": "$0.10",
-            "cost_output": "$0.40",
-            "latency": 0.6
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "DBRX Instruct",
-            "company": "Databricks",
-            "accuracy": 48.0,
-            "cost_input": "$2.25",
-            "cost_output": "$6.75",
-            "latency": 1.26
-        },
-        {
-            "benchmark": "contract_law-05-30-2025",
-            "benchmark_group": "Legal",
-            "model": "Llama 2 (7B)",
-            "company": "Meta",
-            "accuracy": 42.5,
-            "cost_input": "$0.20",
-            "cost_output": "$0.20",
-            "latency": 0.8
-        },
-        {
             "benchmark": "lcb-06-09-2025",
             "benchmark_group": "Coding",
             "model": "o4 Mini",
@@ -3502,106 +2432,6 @@
             "latency": 1.14
         },
         {
-            "benchmark": "swebench-2025-06-13",
-            "benchmark_group": "Coding",
-            "model": "Claude Sonnet 4 (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 65.0,
-            "cost_input": "$1.24",
-            "cost_output": "N/A",
-            "latency": 426.52
-        },
-        {
-            "benchmark": "swebench-2025-06-13",
-            "benchmark_group": "Coding",
-            "model": "o3",
-            "company": "Openai",
-            "accuracy": 49.8,
-            "cost_input": "$1.42",
-            "cost_output": "N/A",
-            "latency": 620.33
-        },
-        {
-            "benchmark": "swebench-2025-06-13",
-            "benchmark_group": "Coding",
-            "model": "GPT 4.1",
-            "company": "Openai",
-            "accuracy": 47.4,
-            "cost_input": "$0.45",
-            "cost_output": "N/A",
-            "latency": 173.98
-        },
-        {
-            "benchmark": "swebench-2025-06-13",
-            "benchmark_group": "Coding",
-            "model": "Gemini 2.5 Pro Preview",
-            "company": "Google",
-            "accuracy": 46.8,
-            "cost_input": "$0.88",
-            "cost_output": "N/A",
-            "latency": 540.96
-        },
-        {
-            "benchmark": "swebench-2025-06-13",
-            "benchmark_group": "Coding",
-            "model": "Gemini 2.5 Flash Preview (Nonthinking)",
-            "company": "Google",
-            "accuracy": 35.6,
-            "cost_input": "$0.11",
-            "cost_output": "N/A",
-            "latency": 251.91
-        },
-        {
-            "benchmark": "swebench-2025-06-13",
-            "benchmark_group": "Coding",
-            "model": "GPT 4.1 Mini",
-            "company": "Openai",
-            "accuracy": 34.8,
-            "cost_input": "$0.13",
-            "cost_output": "N/A",
-            "latency": 233.12
-        },
-        {
-            "benchmark": "swebench-2025-06-13",
-            "benchmark_group": "Coding",
-            "model": "o4 Mini",
-            "company": "Openai",
-            "accuracy": 33.4,
-            "cost_input": "$1.54",
-            "cost_output": "N/A",
-            "latency": 976.81
-        },
-        {
-            "benchmark": "swebench-2025-06-13",
-            "benchmark_group": "Coding",
-            "model": "GPT 4o (2024-08-06)",
-            "company": "Openai",
-            "accuracy": 27.2,
-            "cost_input": "$1.53",
-            "cost_output": "N/A",
-            "latency": 197.58
-        },
-        {
-            "benchmark": "swebench-2025-06-13",
-            "benchmark_group": "Coding",
-            "model": "Llama 4 Maverick",
-            "company": "Meta",
-            "accuracy": 18.4,
-            "cost_input": "$0.12",
-            "cost_output": "N/A",
-            "latency": 62.48
-        },
-        {
-            "benchmark": "swebench-2025-06-13",
-            "benchmark_group": "Coding",
-            "model": "Command A",
-            "company": "Cohere",
-            "accuracy": 0.2,
-            "cost_input": "$0.01",
-            "cost_output": "N/A",
-            "latency": 5.26
-        },
-        {
             "benchmark": "finance_agent-05-30-2025",
             "benchmark_group": "Finance",
             "model": "o3",
@@ -3842,874 +2672,554 @@
             "latency": 36.01
         },
         {
-            "benchmark": "gpqa-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "o3",
-            "company": "Openai",
-            "accuracy": 83.6,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 65.78
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
+            "benchmark": "mmmu-05-30-2025",
             "benchmark_group": "Academic",
             "model": "Gemini 2.5 Pro Exp",
             "company": "Google",
-            "accuracy": 80.3,
+            "accuracy": 81.5,
             "cost_input": "$1.25",
             "cost_output": "$10.00",
-            "latency": 41.1
+            "latency": 24.15
         },
         {
-            "benchmark": "gpqa-05-30-2025",
+            "benchmark": "mmmu-05-30-2025",
             "benchmark_group": "Academic",
-            "model": "Grok 3 Mini Fast High Reasoning",
-            "company": "xAI",
-            "accuracy": 79.0,
-            "cost_input": "$0.60",
-            "cost_output": "$4.00",
-            "latency": 40.62
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "Claude 3.7 Sonnet (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 75.3,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 155.02
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "o3 Mini",
+            "model": "o3",
             "company": "Openai",
-            "accuracy": 75.0,
-            "cost_input": "$1.10",
-            "cost_output": "$4.40",
-            "latency": 99.98
+            "accuracy": 80.1,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 39.27
         },
         {
-            "benchmark": "gpqa-05-30-2025",
+            "benchmark": "mmmu-05-30-2025",
             "benchmark_group": "Academic",
             "model": "o4 Mini",
             "company": "Openai",
-            "accuracy": 74.5,
+            "accuracy": 79.7,
             "cost_input": "$1.10",
             "cost_output": "$4.40",
-            "latency": 30.0
+            "latency": 19.72
         },
         {
-            "benchmark": "gpqa-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "Claude Sonnet 4 (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 74.5,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 118.46
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "Grok 3 Beta",
-            "company": "xAI",
-            "accuracy": 73.7,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 29.91
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
+            "benchmark": "mmmu-05-30-2025",
             "benchmark_group": "Academic",
             "model": "o1",
             "company": "Openai",
-            "accuracy": 73.0,
+            "accuracy": 77.7,
             "cost_input": "$15.00",
             "cost_output": "$60.00",
-            "latency": 40.18
+            "latency": 26.41
         },
         {
-            "benchmark": "gpqa-05-30-2025",
+            "benchmark": "mmmu-05-30-2025",
             "benchmark_group": "Academic",
-            "model": "Grok 3 Mini Fast Low Reasoning",
-            "company": "xAI",
-            "accuracy": 72.7,
-            "cost_input": "$0.60",
-            "cost_output": "$4.00",
-            "latency": 14.23
+            "model": "Claude 3.7 Sonnet (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 76.0,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 69.58
         },
         {
-            "benchmark": "gpqa-05-30-2025",
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Claude Sonnet 4 (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 75.1,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 48.85
+        },
+        {
+            "benchmark": "mmmu-05-30-2025",
             "benchmark_group": "Academic",
             "model": "Claude Opus 4 (Nonthinking)",
             "company": "Anthropic",
-            "accuracy": 71.7,
+            "accuracy": 73.4,
             "cost_input": "$15.00",
             "cost_output": "$75.00",
-            "latency": 19.13
+            "latency": 14.02
         },
         {
-            "benchmark": "gpqa-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "Claude Sonnet 4 (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 69.4,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 12.82
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
+            "benchmark": "mmmu-05-30-2025",
             "benchmark_group": "Academic",
             "model": "Llama 4 Maverick",
             "company": "Meta",
-            "accuracy": 67.7,
+            "accuracy": 72.6,
             "cost_input": "$0.27",
             "cost_output": "$0.85",
-            "latency": 10.07
+            "latency": 7.91
         },
         {
-            "benchmark": "gpqa-05-30-2025",
+            "benchmark": "mmmu-05-30-2025",
             "benchmark_group": "Academic",
-            "model": "Claude 3.7 Sonnet (Nonthinking)",
+            "model": "Claude Sonnet 4 (Nonthinking)",
             "company": "Anthropic",
-            "accuracy": 67.4,
+            "accuracy": 72.6,
             "cost_input": "$3.00",
             "cost_output": "$15.00",
-            "latency": 9.22
+            "latency": 10.82
         },
         {
-            "benchmark": "gpqa-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "GPT 4.1 Mini",
-            "company": "Openai",
-            "accuracy": 67.4,
-            "cost_input": "$0.40",
-            "cost_output": "$1.60",
-            "latency": 9.28
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "Qwen 3 (235B)",
-            "company": "Alibaba",
-            "accuracy": 66.4,
-            "cost_input": "$0.22",
-            "cost_output": "$0.88",
-            "latency": 306.22
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
+            "benchmark": "mmmu-05-30-2025",
             "benchmark_group": "Academic",
             "model": "Gemini 2.0 Flash (001)",
             "company": "Google",
-            "accuracy": 65.2,
+            "accuracy": 71.9,
             "cost_input": "$0.10",
             "cost_output": "$0.40",
-            "latency": 5.8
+            "latency": 45.22
         },
         {
-            "benchmark": "gpqa-05-30-2025",
+            "benchmark": "mmmu-05-30-2025",
             "benchmark_group": "Academic",
-            "model": "GPT 4.1",
+            "model": "Claude 3.7 Sonnet (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 71.6,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 8.32
+        },
+        {
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "GPT 4.1 Mini",
             "company": "Openai",
-            "accuracy": 64.6,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 23.14
+            "accuracy": 71.1,
+            "cost_input": "$0.40",
+            "cost_output": "$1.60",
+            "latency": 8.23
         },
         {
-            "benchmark": "gpqa-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "DeepSeek V3 (03/24/2025)",
-            "company": "Deepseek",
-            "accuracy": 61.1,
-            "cost_input": "$1.20",
-            "cost_output": "$1.20",
-            "latency": 23.48
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
+            "benchmark": "mmmu-05-30-2025",
             "benchmark_group": "Academic",
             "model": "Claude 3.5 Sonnet Latest",
             "company": "Anthropic",
-            "accuracy": 59.1,
+            "accuracy": 68.9,
             "cost_input": "$3.00",
             "cost_output": "$15.00",
-            "latency": 7.24
+            "latency": 46.01
         },
         {
-            "benchmark": "gpqa-05-30-2025",
+            "benchmark": "mmmu-05-30-2025",
             "benchmark_group": "Academic",
-            "model": "Gemini 1.5 Pro (002)",
-            "company": "Google",
-            "accuracy": 58.3,
-            "cost_input": "$1.25",
-            "cost_output": "$5.00",
-            "latency": 7.71
+            "model": "GPT 4.1",
+            "company": "Openai",
+            "accuracy": 68.9,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 12.0
         },
         {
-            "benchmark": "gpqa-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "DeepSeek V3",
-            "company": "Deepseek",
-            "accuracy": 54.0,
-            "cost_input": "$0.90",
-            "cost_output": "$0.90",
-            "latency": 21.28
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "Gemini 2.5 Flash Preview (Nonthinking)",
-            "company": "Google",
-            "accuracy": 53.3,
-            "cost_input": "$0.15",
-            "cost_output": "$0.60",
-            "latency": 43.45
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
+            "benchmark": "mmmu-05-30-2025",
             "benchmark_group": "Academic",
             "model": "GPT 4o (2024-11-20)",
             "company": "Openai",
-            "accuracy": 53.0,
+            "accuracy": 68.1,
             "cost_input": "$2.50",
             "cost_output": "$10.00",
-            "latency": 14.92
+            "latency": 45.87
         },
         {
-            "benchmark": "gpqa-05-30-2025",
+            "benchmark": "mmmu-05-30-2025",
             "benchmark_group": "Academic",
-            "model": "Mistral Small (02/2024)",
-            "company": "Mistral",
-            "accuracy": 50.8,
-            "cost_input": "$0.20",
-            "cost_output": "$0.60",
-            "latency": 7.99
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "GPT 4o (2024-05-13)",
-            "company": "Openai",
-            "accuracy": 50.3,
-            "cost_input": "$5.00",
-            "cost_output": "$15.00",
-            "latency": 10.08
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "Llama 3.3 Instruct Turbo (70B)",
-            "company": "Meta",
-            "accuracy": 50.0,
-            "cost_input": "$0.88",
-            "cost_output": "$0.88",
-            "latency": 7.34
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "Grok 2",
+            "model": "Grok 2 Vision",
             "company": "xAI",
-            "accuracy": 50.0,
+            "accuracy": 66.5,
             "cost_input": "$2.00",
             "cost_output": "$10.00",
-            "latency": 20.18
+            "latency": 18.36
         },
         {
-            "benchmark": "gpqa-05-30-2025",
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Llama 4 Scout",
+            "company": "Meta",
+            "accuracy": 66.5,
+            "cost_input": "$0.18",
+            "cost_output": "$0.59",
+            "latency": 10.51
+        },
+        {
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Gemini 1.5 Pro (002)",
+            "company": "Google",
+            "accuracy": 66.1,
+            "cost_input": "$1.25",
+            "cost_output": "$5.00",
+            "latency": 43.73
+        },
+        {
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "GPT 4o (2024-08-06)",
+            "company": "Openai",
+            "accuracy": 65.5,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 47.53
+        },
+        {
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Mistral Medium 3.1 (05/2025)",
+            "company": "Mistral",
+            "accuracy": 63.1,
+            "cost_input": "$0.40",
+            "cost_output": "$2.00",
+            "latency": 12.56
+        },
+        {
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Mistral Small 3.1 (03/2025)",
+            "company": "Mistral",
+            "accuracy": 60.6,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 13.4
+        },
+        {
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Llama 3.2 Vision (90B)",
+            "company": "Meta",
+            "accuracy": 58.8,
+            "cost_input": "$1.20",
+            "cost_output": "$1.20",
+            "latency": 56.34
+        },
+        {
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "GPT 4o Mini",
+            "company": "Openai",
+            "accuracy": 58.2,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": 45.02
+        },
+        {
+            "benchmark": "mmmu-05-30-2025",
             "benchmark_group": "Academic",
             "model": "Gemini 1.5 Flash (002)",
             "company": "Google",
-            "accuracy": 46.0,
+            "accuracy": 57.6,
             "cost_input": "$0.07",
             "cost_output": "$0.30",
-            "latency": 3.39
+            "latency": 41.31
         },
         {
-            "benchmark": "gpqa-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "Mistral Large (11/2024)",
-            "company": "Mistral",
-            "accuracy": 45.2,
-            "cost_input": "$2.00",
-            "cost_output": "$6.00",
-            "latency": 15.8
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "Llama 4 Scout",
-            "company": "Meta",
-            "accuracy": 44.4,
-            "cost_input": "$0.18",
-            "cost_output": "$0.59",
-            "latency": 12.09
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "GPT 4o Mini",
-            "company": "Openai",
-            "accuracy": 44.2,
-            "cost_input": "$0.15",
-            "cost_output": "$0.60",
-            "latency": 15.32
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "Mistral Small 3.1 (03/2025)",
-            "company": "Mistral",
-            "accuracy": 41.4,
-            "cost_input": "$0.07",
-            "cost_output": "$0.30",
-            "latency": 8.82
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
+            "benchmark": "mmmu-05-30-2025",
             "benchmark_group": "Academic",
             "model": "GPT 4.1 Nano",
             "company": "Openai",
-            "accuracy": 39.9,
+            "accuracy": 55.6,
             "cost_input": "$0.10",
             "cost_output": "$0.40",
-            "latency": 4.19
+            "latency": 7.25
         },
         {
-            "benchmark": "gpqa-05-30-2025",
+            "benchmark": "mmmu-05-30-2025",
             "benchmark_group": "Academic",
-            "model": "Claude 3.5 Haiku Latest",
-            "company": "Anthropic",
-            "accuracy": 37.9,
-            "cost_input": "$1.00",
-            "cost_output": "$5.00",
-            "latency": 6.56
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "GPT 3.5",
-            "company": "Openai",
-            "accuracy": 29.3,
-            "cost_input": "$0.50",
-            "cost_output": "$1.50",
-            "latency": 2.63
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "Command A",
-            "company": "Cohere",
-            "accuracy": 29.3,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 11.49
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "Command R+",
-            "company": "Cohere",
-            "accuracy": 29.0,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 8.19
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "Jamba 1.6 Large",
-            "company": "Ai21 Labs",
-            "accuracy": 24.2,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 15.47
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "benchmark_group": "Academic",
-            "model": "Jamba 1.6 Mini",
-            "company": "Ai21 Labs",
-            "accuracy": 20.5,
-            "cost_input": "$0.20",
-            "cost_output": "$0.40",
-            "latency": 4.95
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "o1",
-            "company": "Openai",
-            "accuracy": 96.5,
-            "cost_input": "$15.00",
-            "cost_output": "$60.00",
-            "latency": 11.15
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "o3",
-            "company": "Openai",
-            "accuracy": 96.1,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 8.51
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "o4 Mini",
-            "company": "Openai",
-            "accuracy": 96.0,
-            "cost_input": "$1.10",
-            "cost_output": "$4.40",
-            "latency": 6.6
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "o3 Mini",
-            "company": "Openai",
-            "accuracy": 94.8,
-            "cost_input": "$1.10",
-            "cost_output": "$4.40",
-            "latency": 8.39
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "Gemini 2.5 Pro Exp",
-            "company": "Google",
-            "accuracy": 93.1,
-            "cost_input": "$1.25",
-            "cost_output": "$10.00",
-            "latency": 10.7
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "o1 Preview",
-            "company": "Openai",
-            "accuracy": 93.0,
-            "cost_input": "$15.00",
-            "cost_output": "$60.00",
-            "latency": 16.44
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "Claude Opus 4 (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 92.9,
-            "cost_input": "$15.00",
-            "cost_output": "$75.00",
-            "latency": 11.93
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "Claude Sonnet 4 (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 92.7,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 26.99
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "Grok 2",
-            "company": "xAI",
-            "accuracy": 92.3,
-            "cost_input": "$2.00",
-            "cost_output": "$10.00",
-            "latency": 4.09
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "GPT 4.1",
-            "company": "Openai",
-            "accuracy": 91.2,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 3.08
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "Gemini 2.5 Flash Preview (Thinking)",
-            "company": "Google",
-            "accuracy": 91.0,
-            "cost_input": "$0.15",
-            "cost_output": "$3.50",
-            "latency": 8.87
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "DeepSeek R1",
-            "company": "Deepseek",
-            "accuracy": 90.8,
-            "cost_input": "$8.00",
-            "cost_output": "$8.00",
-            "latency": 41.57
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "Qwen 3 (235B)",
-            "company": "Alibaba",
-            "accuracy": 90.6,
-            "cost_input": "$0.22",
-            "cost_output": "$0.88",
-            "latency": 26.26
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "Claude Sonnet 4 (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 90.3,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 8.71
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "o1 Mini",
-            "company": "Openai",
-            "accuracy": 90.2,
-            "cost_input": "$3.00",
-            "cost_output": "$12.00",
-            "latency": 5.89
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "Claude 3.7 Sonnet (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 90.2,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 15.74
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "Grok 3 Mini Fast High Reasoning",
-            "company": "xAI",
-            "accuracy": 90.1,
-            "cost_input": "$0.60",
-            "cost_output": "$4.00",
-            "latency": 7.06
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "Grok 3 Mini Fast Low Reasoning",
-            "company": "xAI",
-            "accuracy": 88.6,
-            "cost_input": "$0.60",
-            "cost_output": "$4.00",
-            "latency": 4.88
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "Llama 3.1 Instruct Turbo (405B)",
+            "model": "Llama 3.2 Vision (11B)",
             "company": "Meta",
-            "accuracy": 88.2,
-            "cost_input": "$3.50",
-            "cost_output": "$3.50",
-            "latency": 8.75
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "GPT 4o (2024-08-06)",
-            "company": "Openai",
-            "accuracy": 88.2,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 3.39
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "Gemini 2.5 Flash Preview (Nonthinking)",
-            "company": "Google",
-            "accuracy": 86.7,
-            "cost_input": "$0.15",
-            "cost_output": "$0.60",
-            "latency": 2.25
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "Llama 3.1 Instruct Turbo (70B)",
-            "company": "Meta",
-            "accuracy": 84.8,
-            "cost_input": "$0.88",
-            "cost_output": "$0.88",
-            "latency": 4.8
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "GPT 4.1 Mini",
-            "company": "Openai",
-            "accuracy": 84.6,
-            "cost_input": "$0.40",
-            "cost_output": "$1.60",
-            "latency": 1.86
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "Grok 3 Beta",
-            "company": "xAI",
-            "accuracy": 83.9,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 7.54
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "Claude 3.5 Sonnet Latest",
-            "company": "Anthropic",
-            "accuracy": 83.2,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 5.92
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "DeepSeek V3 (03/24/2025)",
-            "company": "Deepseek",
-            "accuracy": 82.0,
-            "cost_input": "$1.20",
-            "cost_output": "$1.20",
-            "latency": 12.88
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "GPT 4 Turbo",
-            "company": "Openai",
-            "accuracy": 82.0,
-            "cost_input": "$10.00",
-            "cost_output": "$30.00",
-            "latency": 8.41
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "DeepSeek V3",
-            "company": "Deepseek",
-            "accuracy": 80.9,
-            "cost_input": "$0.90",
-            "cost_output": "$0.90",
-            "latency": 6.82
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "Command A",
-            "company": "Cohere",
-            "accuracy": 80.5,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 2.91
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "Mistral Medium 3.1 (05/2025)",
-            "company": "Mistral",
-            "accuracy": 78.2,
-            "cost_input": "$0.40",
-            "cost_output": "$2.00",
-            "latency": 7.34
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "Qwen 2.5 Instruct Turbo (72B)",
-            "company": "Alibaba",
-            "accuracy": 77.4,
-            "cost_input": "$1.20",
-            "cost_output": "$1.20",
-            "latency": 5.57
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "Gemini 1.5 Pro (002)",
-            "company": "Google",
-            "accuracy": 76.5,
-            "cost_input": "$1.25",
-            "cost_output": "$5.00",
-            "latency": 5.93
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "Mistral Large (11/2024)",
-            "company": "Mistral",
-            "accuracy": 76.2,
-            "cost_input": "$2.00",
-            "cost_output": "$6.00",
-            "latency": 4.86
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "GPT 4o Mini",
-            "company": "Openai",
-            "accuracy": 72.4,
-            "cost_input": "$0.15",
-            "cost_output": "$0.60",
-            "latency": 2.32
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "Mistral Small 3.1 (03/2025)",
-            "company": "Mistral",
-            "accuracy": 69.1,
-            "cost_input": "$0.07",
-            "cost_output": "$0.30",
-            "latency": 3.63
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "GPT 4.1 Nano",
-            "company": "Openai",
-            "accuracy": 68.2,
-            "cost_input": "$0.10",
-            "cost_output": "$0.40",
-            "latency": 1.42
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "Jamba 1.5 Large",
-            "company": "Ai21 Labs",
-            "accuracy": 68.1,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 6.0
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "Llama 3.1 Instruct Turbo (8B)",
-            "company": "Meta",
-            "accuracy": 62.6,
+            "accuracy": 50.3,
             "cost_input": "$0.18",
             "cost_output": "$0.18",
-            "latency": 2.37
+            "latency": 38.07
         },
         {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "GPT 3.5",
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Claude 3.7 Sonnet (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 80.6,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 5.67
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Claude 3.7 Sonnet (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 79.2,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 13.58
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4.1",
             "company": "Openai",
-            "accuracy": 58.5,
-            "cost_input": "$0.50",
-            "cost_output": "$1.50",
-            "latency": 1.59
+            "accuracy": 79.0,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 5.03
         },
         {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "Mistral Small (02/2024)",
-            "company": "Mistral",
-            "accuracy": 57.0,
-            "cost_input": "$0.20",
-            "cost_output": "$0.60",
-            "latency": 2.76
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 2.5 Pro Exp",
+            "company": "Google",
+            "accuracy": 78.8,
+            "cost_input": "$1.25",
+            "cost_output": "$10.00",
+            "latency": 8.91
         },
         {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "Jamba 1.5 Mini",
-            "company": "Ai21 Labs",
-            "accuracy": 55.2,
-            "cost_input": "$0.20",
-            "cost_output": "$0.40",
-            "latency": 1.14
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "o3",
+            "company": "Openai",
+            "accuracy": 78.4,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 21.22
         },
         {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "Mixtral (8x7B)",
-            "company": "Mistral",
-            "accuracy": 53.2,
-            "cost_input": "$0.60",
-            "cost_output": "$0.60",
-            "latency": 3.49
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Claude 3.5 Sonnet Latest",
+            "company": "Anthropic",
+            "accuracy": 78.1,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 4.22
         },
         {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "Jamba 1.6 Mini",
-            "company": "Ai21 Labs",
-            "accuracy": 52.5,
-            "cost_input": "$0.20",
-            "cost_output": "$0.40",
-            "latency": 2.19
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4.1 Mini",
+            "company": "Openai",
+            "accuracy": 77.7,
+            "cost_input": "$0.40",
+            "cost_output": "$1.60",
+            "latency": 4.6
         },
         {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "Command R+",
-            "company": "Cohere",
-            "accuracy": 51.4,
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "o4 Mini",
+            "company": "Openai",
+            "accuracy": 77.1,
+            "cost_input": "$1.10",
+            "cost_output": "$4.40",
+            "latency": 13.0
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4o (2024-08-06)",
+            "company": "Openai",
+            "accuracy": 75.2,
             "cost_input": "$2.50",
             "cost_output": "$10.00",
+            "latency": 7.36
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Mistral Small 3.1 (03/2025)",
+            "company": "Mistral",
+            "accuracy": 75.0,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 8.31
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Claude Sonnet 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 74.6,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 8.42
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Llama 4 Maverick",
+            "company": "Meta",
+            "accuracy": 72.7,
+            "cost_input": "$0.27",
+            "cost_output": "$0.85",
+            "latency": 2.72
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 2.0 Flash (001)",
+            "company": "Google",
+            "accuracy": 72.6,
+            "cost_input": "$0.10",
+            "cost_output": "$0.40",
+            "latency": 3.79
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4o (2024-11-20)",
+            "company": "Openai",
+            "accuracy": 72.1,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 5.98
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Llama 4 Scout",
+            "company": "Meta",
+            "accuracy": 71.7,
+            "cost_input": "$0.18",
+            "cost_output": "$0.59",
+            "latency": 2.43
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 1.5 Pro (002)",
+            "company": "Google",
+            "accuracy": 71.0,
+            "cost_input": "$1.25",
+            "cost_output": "$5.00",
+            "latency": 4.2
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 2.5 Flash Preview (Nonthinking)",
+            "company": "Google",
+            "accuracy": 70.9,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": 3.56
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Claude Opus 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 70.9,
+            "cost_input": "$15.00",
+            "cost_output": "$75.00",
+            "latency": 13.76
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 2.5 Flash Preview (Thinking)",
+            "company": "Google",
+            "accuracy": 69.5,
+            "cost_input": "$0.15",
+            "cost_output": "$3.50",
+            "latency": 8.4
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4o Mini",
+            "company": "Openai",
+            "accuracy": 69.2,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
             "latency": 6.06
         },
         {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "Llama 4 Scout",
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4.1 Nano",
+            "company": "Openai",
+            "accuracy": 67.0,
+            "cost_input": "$0.10",
+            "cost_output": "$0.40",
+            "latency": 3.86
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Nova Lite",
+            "company": "Amazon",
+            "accuracy": 66.1,
+            "cost_input": "$0.06",
+            "cost_output": "$0.24",
+            "latency": null
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Nova Pro",
+            "company": "Amazon",
+            "accuracy": 63.7,
+            "cost_input": "$0.80",
+            "cost_output": "$3.20",
+            "latency": null
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Claude Sonnet 4 (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 62.5,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 46.32
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Mistral Medium 3.1 (05/2025)",
+            "company": "Mistral",
+            "accuracy": 60.5,
+            "cost_input": "$0.40",
+            "cost_output": "$2.00",
+            "latency": 7.14
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Llama 3.2 Vision (90B)",
             "company": "Meta",
-            "accuracy": 50.9,
+            "accuracy": 55.0,
+            "cost_input": "$1.20",
+            "cost_output": "$1.20",
+            "latency": 5.07
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 1.5 Flash (002)",
+            "company": "Google",
+            "accuracy": 54.6,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 2.1
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Llama 3.2 Vision (11B)",
+            "company": "Meta",
+            "accuracy": 38.8,
             "cost_input": "$0.18",
-            "cost_output": "$0.59",
-            "latency": 4.8
+            "cost_output": "$0.18",
+            "latency": 2.45
         },
         {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "Jamba 1.6 Large",
-            "company": "Ai21 Labs",
-            "accuracy": 50.7,
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Grok 2 Vision",
+            "company": "xAI",
+            "accuracy": 26.7,
             "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 7.31
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "benchmark_group": "Healthcare",
-            "model": "Llama 4 Maverick",
-            "company": "Meta",
-            "accuracy": 43.3,
-            "cost_input": "$0.27",
-            "cost_output": "$0.85",
-            "latency": 7.75
+            "cost_output": "$10.00",
+            "latency": null
         },
         {
             "benchmark": "case_law-05-30-2025",
@@ -5330,686 +3840,6 @@
             "cost_input": "$0.18",
             "cost_output": "$0.18",
             "latency": 4.33
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "GPT 4.1",
-            "company": "Openai",
-            "accuracy": 71.2,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 10.33
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "o3",
-            "company": "Openai",
-            "accuracy": 71.0,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 19.13
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "o4 Mini",
-            "company": "Openai",
-            "accuracy": 70.1,
-            "cost_input": "$1.10",
-            "cost_output": "$4.40",
-            "latency": 17.5
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Grok 3 Beta",
-            "company": "xAI",
-            "accuracy": 69.1,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 23.86
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Grok 3 Mini Fast High Reasoning",
-            "company": "xAI",
-            "accuracy": 68.6,
-            "cost_input": "$0.60",
-            "cost_output": "$4.00",
-            "latency": 14.12
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Gemini 2.5 Pro Exp",
-            "company": "Google",
-            "accuracy": 68.4,
-            "cost_input": "$1.25",
-            "cost_output": "$10.00",
-            "latency": 17.99
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Claude 3.7 Sonnet (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 68.0,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 22.33
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Claude Sonnet 4 (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 67.3,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 227.37
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Grok 3 Mini Fast Low Reasoning",
-            "company": "xAI",
-            "accuracy": 66.0,
-            "cost_input": "$0.60",
-            "cost_output": "$4.00",
-            "latency": 10.42
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "GPT 4.1 Mini",
-            "company": "Openai",
-            "accuracy": 65.8,
-            "cost_input": "$0.40",
-            "cost_output": "$1.60",
-            "latency": 6.56
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "DeepSeek R1",
-            "company": "Deepseek",
-            "accuracy": 63.2,
-            "cost_input": "$8.00",
-            "cost_output": "$8.00",
-            "latency": 46.8
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Gemini 2.5 Flash Preview (Nonthinking)",
-            "company": "Google",
-            "accuracy": 62.6,
-            "cost_input": "$0.15",
-            "cost_output": "$0.60",
-            "latency": 8.67
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "DeepSeek V3 (03/24/2025)",
-            "company": "Deepseek",
-            "accuracy": 60.9,
-            "cost_input": "$1.20",
-            "cost_output": "$1.20",
-            "latency": 36.59
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "DeepSeek V3",
-            "company": "Deepseek",
-            "accuracy": 60.7,
-            "cost_input": "$0.90",
-            "cost_output": "$0.90",
-            "latency": 28.88
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Claude 3.5 Sonnet Latest",
-            "company": "Anthropic",
-            "accuracy": 60.5,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": null
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Claude Sonnet 4 (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 59.9,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 162.67
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Claude 3.5 Haiku Latest",
-            "company": "Anthropic",
-            "accuracy": 58.2,
-            "cost_input": "$1.00",
-            "cost_output": "$5.00",
-            "latency": null
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Grok 2",
-            "company": "xAI",
-            "accuracy": 58.2,
-            "cost_input": "$2.00",
-            "cost_output": "$10.00",
-            "latency": 84.8
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Mistral Medium 3.1 (05/2025)",
-            "company": "Mistral",
-            "accuracy": 58.1,
-            "cost_input": "$0.40",
-            "cost_output": "$2.00",
-            "latency": 30.56
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Llama 4 Maverick",
-            "company": "Meta",
-            "accuracy": 57.6,
-            "cost_input": "$0.27",
-            "cost_output": "$0.85",
-            "latency": 6.59
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "GPT 4o (2024-11-20)",
-            "company": "Openai",
-            "accuracy": 56.6,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 6.35
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "o3 Mini",
-            "company": "Openai",
-            "accuracy": 55.7,
-            "cost_input": "$1.10",
-            "cost_output": "$4.40",
-            "latency": 31.42
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "GPT 4o Mini",
-            "company": "Openai",
-            "accuracy": 55.0,
-            "cost_input": "$0.15",
-            "cost_output": "$0.60",
-            "latency": null
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Command A",
-            "company": "Cohere",
-            "accuracy": 54.5,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 14.34
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Llama 4 Scout",
-            "company": "Meta",
-            "accuracy": 53.9,
-            "cost_input": "$0.18",
-            "cost_output": "$0.59",
-            "latency": 9.22
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Mistral Small 3.1 (03/2025)",
-            "company": "Mistral",
-            "accuracy": 53.2,
-            "cost_input": "$0.07",
-            "cost_output": "$0.30",
-            "latency": 12.25
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Gemini 2.0 Pro Exp",
-            "company": "Google",
-            "accuracy": 53.1,
-            "cost_input": "$1.25",
-            "cost_output": "$5.00",
-            "latency": 18.13
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "GPT 4.1 Nano",
-            "company": "Openai",
-            "accuracy": 52.4,
-            "cost_input": "$0.10",
-            "cost_output": "$0.40",
-            "latency": 12.47
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Jamba 1.6 Large",
-            "company": "Ai21 Labs",
-            "accuracy": 50.7,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 29.61
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Gemini 1.5 Pro (002)",
-            "company": "Google",
-            "accuracy": 50.3,
-            "cost_input": "$1.25",
-            "cost_output": "$5.00",
-            "latency": 37.35
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "GPT 4o (2024-08-06)",
-            "company": "Openai",
-            "accuracy": 49.3,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": null
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Llama 3.1 Instruct Turbo (70B)",
-            "company": "Meta",
-            "accuracy": 47.2,
-            "cost_input": "$0.88",
-            "cost_output": "$0.88",
-            "latency": null
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Jamba 1.5 Large",
-            "company": "Ai21 Labs",
-            "accuracy": 46.6,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 10.74
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Gemini 1.5 Flash (002)",
-            "company": "Google",
-            "accuracy": 46.6,
-            "cost_input": "$0.07",
-            "cost_output": "$0.30",
-            "latency": 28.38
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Jamba 1.6 Mini",
-            "company": "Ai21 Labs",
-            "accuracy": 46.0,
-            "cost_input": "$0.20",
-            "cost_output": "$0.40",
-            "latency": 4.28
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Llama 3.1 Instruct Turbo (8B)",
-            "company": "Meta",
-            "accuracy": 43.5,
-            "cost_input": "$0.18",
-            "cost_output": "$0.18",
-            "latency": null
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Jamba 1.5 Mini",
-            "company": "Ai21 Labs",
-            "accuracy": 39.9,
-            "cost_input": "$0.20",
-            "cost_output": "$0.40",
-            "latency": 2.34
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Gemini 2.0 Flash (001)",
-            "company": "Google",
-            "accuracy": 38.5,
-            "cost_input": "$0.10",
-            "cost_output": "$0.40",
-            "latency": 31.35
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Gemini 1.5 Flash (001)",
-            "company": "Google",
-            "accuracy": 32.9,
-            "cost_input": "$0.07",
-            "cost_output": "$0.30",
-            "latency": null
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Claude 3.7 Sonnet (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 80.6,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 5.67
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Claude 3.7 Sonnet (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 79.2,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 13.58
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "GPT 4.1",
-            "company": "Openai",
-            "accuracy": 79.0,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 5.03
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Gemini 2.5 Pro Exp",
-            "company": "Google",
-            "accuracy": 78.8,
-            "cost_input": "$1.25",
-            "cost_output": "$10.00",
-            "latency": 8.91
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "o3",
-            "company": "Openai",
-            "accuracy": 78.4,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 21.22
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Claude 3.5 Sonnet Latest",
-            "company": "Anthropic",
-            "accuracy": 78.1,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 4.22
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "GPT 4.1 Mini",
-            "company": "Openai",
-            "accuracy": 77.7,
-            "cost_input": "$0.40",
-            "cost_output": "$1.60",
-            "latency": 4.6
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "o4 Mini",
-            "company": "Openai",
-            "accuracy": 77.1,
-            "cost_input": "$1.10",
-            "cost_output": "$4.40",
-            "latency": 13.0
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "GPT 4o (2024-08-06)",
-            "company": "Openai",
-            "accuracy": 75.2,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 7.36
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Mistral Small 3.1 (03/2025)",
-            "company": "Mistral",
-            "accuracy": 75.0,
-            "cost_input": "$0.07",
-            "cost_output": "$0.30",
-            "latency": 8.31
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Claude Sonnet 4 (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 74.6,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 8.42
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Llama 4 Maverick",
-            "company": "Meta",
-            "accuracy": 72.7,
-            "cost_input": "$0.27",
-            "cost_output": "$0.85",
-            "latency": 2.72
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Gemini 2.0 Flash (001)",
-            "company": "Google",
-            "accuracy": 72.6,
-            "cost_input": "$0.10",
-            "cost_output": "$0.40",
-            "latency": 3.79
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "GPT 4o (2024-11-20)",
-            "company": "Openai",
-            "accuracy": 72.1,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 5.98
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Llama 4 Scout",
-            "company": "Meta",
-            "accuracy": 71.7,
-            "cost_input": "$0.18",
-            "cost_output": "$0.59",
-            "latency": 2.43
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Gemini 1.5 Pro (002)",
-            "company": "Google",
-            "accuracy": 71.0,
-            "cost_input": "$1.25",
-            "cost_output": "$5.00",
-            "latency": 4.2
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Gemini 2.5 Flash Preview (Nonthinking)",
-            "company": "Google",
-            "accuracy": 70.9,
-            "cost_input": "$0.15",
-            "cost_output": "$0.60",
-            "latency": 3.56
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Claude Opus 4 (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 70.9,
-            "cost_input": "$15.00",
-            "cost_output": "$75.00",
-            "latency": 13.76
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Gemini 2.5 Flash Preview (Thinking)",
-            "company": "Google",
-            "accuracy": 69.5,
-            "cost_input": "$0.15",
-            "cost_output": "$3.50",
-            "latency": 8.4
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "GPT 4o Mini",
-            "company": "Openai",
-            "accuracy": 69.2,
-            "cost_input": "$0.15",
-            "cost_output": "$0.60",
-            "latency": 6.06
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "GPT 4.1 Nano",
-            "company": "Openai",
-            "accuracy": 67.0,
-            "cost_input": "$0.10",
-            "cost_output": "$0.40",
-            "latency": 3.86
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Nova Lite",
-            "company": "Amazon",
-            "accuracy": 66.1,
-            "cost_input": "$0.06",
-            "cost_output": "$0.24",
-            "latency": null
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Nova Pro",
-            "company": "Amazon",
-            "accuracy": 63.7,
-            "cost_input": "$0.80",
-            "cost_output": "$3.20",
-            "latency": null
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Claude Sonnet 4 (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 62.5,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 46.32
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Mistral Medium 3.1 (05/2025)",
-            "company": "Mistral",
-            "accuracy": 60.5,
-            "cost_input": "$0.40",
-            "cost_output": "$2.00",
-            "latency": 7.14
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Llama 3.2 Vision (90B)",
-            "company": "Meta",
-            "accuracy": 55.0,
-            "cost_input": "$1.20",
-            "cost_output": "$1.20",
-            "latency": 5.07
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Gemini 1.5 Flash (002)",
-            "company": "Google",
-            "accuracy": 54.6,
-            "cost_input": "$0.07",
-            "cost_output": "$0.30",
-            "latency": 2.1
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Llama 3.2 Vision (11B)",
-            "company": "Meta",
-            "accuracy": 38.8,
-            "cost_input": "$0.18",
-            "cost_output": "$0.18",
-            "latency": 2.45
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "benchmark_group": "Finance",
-            "model": "Grok 2 Vision",
-            "company": "xAI",
-            "accuracy": 26.7,
-            "cost_input": "$2.00",
-            "cost_output": "$10.00",
-            "latency": null
         },
         {
             "benchmark": "mgsm-2025-05-30",
@@ -6930,6 +4760,2176 @@
             "cost_input": "$0.18",
             "cost_output": "$0.18",
             "latency": 2.45
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "o1",
+            "company": "Openai",
+            "accuracy": 96.5,
+            "cost_input": "$15.00",
+            "cost_output": "$60.00",
+            "latency": 11.15
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "o3",
+            "company": "Openai",
+            "accuracy": 96.1,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 8.51
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "o4 Mini",
+            "company": "Openai",
+            "accuracy": 96.0,
+            "cost_input": "$1.10",
+            "cost_output": "$4.40",
+            "latency": 6.6
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "o3 Mini",
+            "company": "Openai",
+            "accuracy": 94.8,
+            "cost_input": "$1.10",
+            "cost_output": "$4.40",
+            "latency": 8.39
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Gemini 2.5 Pro Exp",
+            "company": "Google",
+            "accuracy": 93.1,
+            "cost_input": "$1.25",
+            "cost_output": "$10.00",
+            "latency": 10.7
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "o1 Preview",
+            "company": "Openai",
+            "accuracy": 93.0,
+            "cost_input": "$15.00",
+            "cost_output": "$60.00",
+            "latency": 16.44
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Claude Opus 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 92.9,
+            "cost_input": "$15.00",
+            "cost_output": "$75.00",
+            "latency": 11.93
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Claude Sonnet 4 (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 92.7,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 26.99
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Grok 2",
+            "company": "xAI",
+            "accuracy": 92.3,
+            "cost_input": "$2.00",
+            "cost_output": "$10.00",
+            "latency": 4.09
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "GPT 4.1",
+            "company": "Openai",
+            "accuracy": 91.2,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 3.08
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Gemini 2.5 Flash Preview (Thinking)",
+            "company": "Google",
+            "accuracy": 91.0,
+            "cost_input": "$0.15",
+            "cost_output": "$3.50",
+            "latency": 8.87
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "DeepSeek R1",
+            "company": "Deepseek",
+            "accuracy": 90.8,
+            "cost_input": "$8.00",
+            "cost_output": "$8.00",
+            "latency": 41.57
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Qwen 3 (235B)",
+            "company": "Alibaba",
+            "accuracy": 90.6,
+            "cost_input": "$0.22",
+            "cost_output": "$0.88",
+            "latency": 26.26
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Claude Sonnet 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 90.3,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 8.71
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "o1 Mini",
+            "company": "Openai",
+            "accuracy": 90.2,
+            "cost_input": "$3.00",
+            "cost_output": "$12.00",
+            "latency": 5.89
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Claude 3.7 Sonnet (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 90.2,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 15.74
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Grok 3 Mini Fast High Reasoning",
+            "company": "xAI",
+            "accuracy": 90.1,
+            "cost_input": "$0.60",
+            "cost_output": "$4.00",
+            "latency": 7.06
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Grok 3 Mini Fast Low Reasoning",
+            "company": "xAI",
+            "accuracy": 88.6,
+            "cost_input": "$0.60",
+            "cost_output": "$4.00",
+            "latency": 4.88
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Llama 3.1 Instruct Turbo (405B)",
+            "company": "Meta",
+            "accuracy": 88.2,
+            "cost_input": "$3.50",
+            "cost_output": "$3.50",
+            "latency": 8.75
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "GPT 4o (2024-08-06)",
+            "company": "Openai",
+            "accuracy": 88.2,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 3.39
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Gemini 2.5 Flash Preview (Nonthinking)",
+            "company": "Google",
+            "accuracy": 86.7,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": 2.25
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Llama 3.1 Instruct Turbo (70B)",
+            "company": "Meta",
+            "accuracy": 84.8,
+            "cost_input": "$0.88",
+            "cost_output": "$0.88",
+            "latency": 4.8
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "GPT 4.1 Mini",
+            "company": "Openai",
+            "accuracy": 84.6,
+            "cost_input": "$0.40",
+            "cost_output": "$1.60",
+            "latency": 1.86
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Grok 3 Beta",
+            "company": "xAI",
+            "accuracy": 83.9,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 7.54
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Claude 3.5 Sonnet Latest",
+            "company": "Anthropic",
+            "accuracy": 83.2,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 5.92
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "DeepSeek V3 (03/24/2025)",
+            "company": "Deepseek",
+            "accuracy": 82.0,
+            "cost_input": "$1.20",
+            "cost_output": "$1.20",
+            "latency": 12.88
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "GPT 4 Turbo",
+            "company": "Openai",
+            "accuracy": 82.0,
+            "cost_input": "$10.00",
+            "cost_output": "$30.00",
+            "latency": 8.41
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "DeepSeek V3",
+            "company": "Deepseek",
+            "accuracy": 80.9,
+            "cost_input": "$0.90",
+            "cost_output": "$0.90",
+            "latency": 6.82
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Command A",
+            "company": "Cohere",
+            "accuracy": 80.5,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 2.91
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Mistral Medium 3.1 (05/2025)",
+            "company": "Mistral",
+            "accuracy": 78.2,
+            "cost_input": "$0.40",
+            "cost_output": "$2.00",
+            "latency": 7.34
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Qwen 2.5 Instruct Turbo (72B)",
+            "company": "Alibaba",
+            "accuracy": 77.4,
+            "cost_input": "$1.20",
+            "cost_output": "$1.20",
+            "latency": 5.57
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Gemini 1.5 Pro (002)",
+            "company": "Google",
+            "accuracy": 76.5,
+            "cost_input": "$1.25",
+            "cost_output": "$5.00",
+            "latency": 5.93
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Mistral Large (11/2024)",
+            "company": "Mistral",
+            "accuracy": 76.2,
+            "cost_input": "$2.00",
+            "cost_output": "$6.00",
+            "latency": 4.86
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "GPT 4o Mini",
+            "company": "Openai",
+            "accuracy": 72.4,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": 2.32
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Mistral Small 3.1 (03/2025)",
+            "company": "Mistral",
+            "accuracy": 69.1,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 3.63
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "GPT 4.1 Nano",
+            "company": "Openai",
+            "accuracy": 68.2,
+            "cost_input": "$0.10",
+            "cost_output": "$0.40",
+            "latency": 1.42
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Jamba 1.5 Large",
+            "company": "Ai21 Labs",
+            "accuracy": 68.1,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 6.0
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Llama 3.1 Instruct Turbo (8B)",
+            "company": "Meta",
+            "accuracy": 62.6,
+            "cost_input": "$0.18",
+            "cost_output": "$0.18",
+            "latency": 2.37
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "GPT 3.5",
+            "company": "Openai",
+            "accuracy": 58.5,
+            "cost_input": "$0.50",
+            "cost_output": "$1.50",
+            "latency": 1.59
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Mistral Small (02/2024)",
+            "company": "Mistral",
+            "accuracy": 57.0,
+            "cost_input": "$0.20",
+            "cost_output": "$0.60",
+            "latency": 2.76
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Jamba 1.5 Mini",
+            "company": "Ai21 Labs",
+            "accuracy": 55.2,
+            "cost_input": "$0.20",
+            "cost_output": "$0.40",
+            "latency": 1.14
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Mixtral (8x7B)",
+            "company": "Mistral",
+            "accuracy": 53.2,
+            "cost_input": "$0.60",
+            "cost_output": "$0.60",
+            "latency": 3.49
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Jamba 1.6 Mini",
+            "company": "Ai21 Labs",
+            "accuracy": 52.5,
+            "cost_input": "$0.20",
+            "cost_output": "$0.40",
+            "latency": 2.19
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Command R+",
+            "company": "Cohere",
+            "accuracy": 51.4,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 6.06
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Llama 4 Scout",
+            "company": "Meta",
+            "accuracy": 50.9,
+            "cost_input": "$0.18",
+            "cost_output": "$0.59",
+            "latency": 4.8
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Jamba 1.6 Large",
+            "company": "Ai21 Labs",
+            "accuracy": 50.7,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 7.31
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Llama 4 Maverick",
+            "company": "Meta",
+            "accuracy": 43.3,
+            "cost_input": "$0.27",
+            "cost_output": "$0.85",
+            "latency": 7.75
+        },
+        {
+            "benchmark": "swebench-2025-06-13",
+            "benchmark_group": "Coding",
+            "model": "Claude Sonnet 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 65.0,
+            "cost_input": "$1.24",
+            "cost_output": "N/A",
+            "latency": 426.52
+        },
+        {
+            "benchmark": "swebench-2025-06-13",
+            "benchmark_group": "Coding",
+            "model": "o3",
+            "company": "Openai",
+            "accuracy": 49.8,
+            "cost_input": "$1.42",
+            "cost_output": "N/A",
+            "latency": 620.33
+        },
+        {
+            "benchmark": "swebench-2025-06-13",
+            "benchmark_group": "Coding",
+            "model": "GPT 4.1",
+            "company": "Openai",
+            "accuracy": 47.4,
+            "cost_input": "$0.45",
+            "cost_output": "N/A",
+            "latency": 173.98
+        },
+        {
+            "benchmark": "swebench-2025-06-13",
+            "benchmark_group": "Coding",
+            "model": "Gemini 2.5 Pro Preview",
+            "company": "Google",
+            "accuracy": 46.8,
+            "cost_input": "$0.88",
+            "cost_output": "N/A",
+            "latency": 540.96
+        },
+        {
+            "benchmark": "swebench-2025-06-13",
+            "benchmark_group": "Coding",
+            "model": "Gemini 2.5 Flash Preview (Nonthinking)",
+            "company": "Google",
+            "accuracy": 35.6,
+            "cost_input": "$0.11",
+            "cost_output": "N/A",
+            "latency": 251.91
+        },
+        {
+            "benchmark": "swebench-2025-06-13",
+            "benchmark_group": "Coding",
+            "model": "GPT 4.1 Mini",
+            "company": "Openai",
+            "accuracy": 34.8,
+            "cost_input": "$0.13",
+            "cost_output": "N/A",
+            "latency": 233.12
+        },
+        {
+            "benchmark": "swebench-2025-06-13",
+            "benchmark_group": "Coding",
+            "model": "o4 Mini",
+            "company": "Openai",
+            "accuracy": 33.4,
+            "cost_input": "$1.54",
+            "cost_output": "N/A",
+            "latency": 976.81
+        },
+        {
+            "benchmark": "swebench-2025-06-13",
+            "benchmark_group": "Coding",
+            "model": "GPT 4o (2024-08-06)",
+            "company": "Openai",
+            "accuracy": 27.2,
+            "cost_input": "$1.53",
+            "cost_output": "N/A",
+            "latency": 197.58
+        },
+        {
+            "benchmark": "swebench-2025-06-13",
+            "benchmark_group": "Coding",
+            "model": "Llama 4 Maverick",
+            "company": "Meta",
+            "accuracy": 18.4,
+            "cost_input": "$0.12",
+            "cost_output": "N/A",
+            "latency": 62.48
+        },
+        {
+            "benchmark": "swebench-2025-06-13",
+            "benchmark_group": "Coding",
+            "model": "Command A",
+            "company": "Cohere",
+            "accuracy": 0.2,
+            "cost_input": "$0.01",
+            "cost_output": "N/A",
+            "latency": 5.26
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 3.1 Instruct Turbo (405B)",
+            "company": "Meta",
+            "accuracy": 75.2,
+            "cost_input": "$3.50",
+            "cost_output": "$3.50",
+            "latency": 2.19
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude 3 Opus",
+            "company": "Anthropic",
+            "accuracy": 74.0,
+            "cost_input": "$15.00",
+            "cost_output": "$75.00",
+            "latency": 5.97
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Qwen 2.5 Instruct Turbo (72B)",
+            "company": "Alibaba",
+            "accuracy": 73.6,
+            "cost_input": "$1.20",
+            "cost_output": "$1.20",
+            "latency": 1.01
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude 3.7 Sonnet (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 73.0,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 8.87
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "o1 Mini",
+            "company": "Openai",
+            "accuracy": 72.8,
+            "cost_input": "$3.00",
+            "cost_output": "$12.00",
+            "latency": 4.01
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "o1",
+            "company": "Openai",
+            "accuracy": 72.7,
+            "cost_input": "$15.00",
+            "cost_output": "$60.00",
+            "latency": 11.26
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "GPT 4o Mini",
+            "company": "Openai",
+            "accuracy": 72.4,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": 1.92
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude Sonnet 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 72.4,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 2.91
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "GPT 4 Turbo",
+            "company": "Openai",
+            "accuracy": 71.8,
+            "cost_input": "$10.00",
+            "cost_output": "$30.00",
+            "latency": 3.26
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "GPT 4.1 Mini",
+            "company": "Openai",
+            "accuracy": 71.5,
+            "cost_input": "$0.40",
+            "cost_output": "$1.60",
+            "latency": 1.03
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Grok 3 Mini Fast Low Reasoning",
+            "company": "xAI",
+            "accuracy": 70.8,
+            "cost_input": "$0.60",
+            "cost_output": "$4.00",
+            "latency": 4.92
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemini 1.5 Flash (002)",
+            "company": "Google",
+            "accuracy": 70.4,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 0.8
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "o3 Mini",
+            "company": "Openai",
+            "accuracy": 69.3,
+            "cost_input": "$1.10",
+            "cost_output": "$4.40",
+            "latency": 46.24
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "o1 Preview",
+            "company": "Openai",
+            "accuracy": 69.0,
+            "cost_input": "$15.00",
+            "cost_output": "$60.00",
+            "latency": 12.83
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "o4 Mini",
+            "company": "Openai",
+            "accuracy": 68.9,
+            "cost_input": "$1.10",
+            "cost_output": "$4.40",
+            "latency": 4.53
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude Opus 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 68.8,
+            "cost_input": "$15.00",
+            "cost_output": "$75.00",
+            "latency": 4.37
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude 3.5 Sonnet Latest",
+            "company": "Anthropic",
+            "accuracy": 68.7,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 2.28
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude 3.5 Haiku Latest",
+            "company": "Anthropic",
+            "accuracy": 68.7,
+            "cost_input": "$1.00",
+            "cost_output": "$5.00",
+            "latency": 2.88
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 3.1 Instruct Turbo (70B)",
+            "company": "Meta",
+            "accuracy": 68.6,
+            "cost_input": "$0.88",
+            "cost_output": "$0.88",
+            "latency": 4.74
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "GPT 4.1",
+            "company": "Openai",
+            "accuracy": 68.4,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 1.11
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "DeepSeek V3",
+            "company": "Deepseek",
+            "accuracy": 68.4,
+            "cost_input": "$0.90",
+            "cost_output": "$0.90",
+            "latency": 2.15
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Command R+",
+            "company": "Cohere",
+            "accuracy": 68.2,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 1.17
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude 3.5 Sonnet",
+            "company": "Anthropic",
+            "accuracy": 68.2,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 1.61
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude 3.7 Sonnet (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 68.1,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 2.29
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemini 1.5 Pro (001)",
+            "company": "Google",
+            "accuracy": 68.0,
+            "cost_input": "$1.25",
+            "cost_output": "$5.00",
+            "latency": 4.11
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemini 1.5 Pro (002)",
+            "company": "Google",
+            "accuracy": 68.0,
+            "cost_input": "$1.25",
+            "cost_output": "$5.00",
+            "latency": 4.11
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "GPT 4o (2024-11-20)",
+            "company": "Openai",
+            "accuracy": 68.0,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 1.03
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Command A",
+            "company": "Cohere",
+            "accuracy": 67.7,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 1.44
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude 3 Sonnet",
+            "company": "Anthropic",
+            "accuracy": 67.6,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 3.03
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Mistral Large (11/2024)",
+            "company": "Mistral",
+            "accuracy": 67.0,
+            "cost_input": "$2.00",
+            "cost_output": "$6.00",
+            "latency": 2.16
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemini 2.0 Flash (001)",
+            "company": "Google",
+            "accuracy": 66.8,
+            "cost_input": "$0.10",
+            "cost_output": "$0.40",
+            "latency": 0.7
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 3 (70B)",
+            "company": "Meta",
+            "accuracy": 66.8,
+            "cost_input": "$0.90",
+            "cost_output": "$0.90",
+            "latency": 2.92
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemini 1.0 Pro 002",
+            "company": "Google",
+            "accuracy": 66.7,
+            "cost_input": "$0.50",
+            "cost_output": "$1.50",
+            "latency": 0.89
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Command R",
+            "company": "Cohere",
+            "accuracy": 66.7,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": 0.56
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Mistral Medium 3.1 (05/2025)",
+            "company": "Mistral",
+            "accuracy": 66.2,
+            "cost_input": "$0.40",
+            "cost_output": "$2.00",
+            "latency": 1.99
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Jamba 1.6 Mini",
+            "company": "Ai21 Labs",
+            "accuracy": 66.1,
+            "cost_input": "$0.20",
+            "cost_output": "$0.40",
+            "latency": 0.61
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "o3",
+            "company": "Openai",
+            "accuracy": 66.0,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 6.02
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 3.3 Instruct Turbo (70B)",
+            "company": "Meta",
+            "accuracy": 66.0,
+            "cost_input": "$0.88",
+            "cost_output": "$0.88",
+            "latency": 1.01
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude Sonnet 4 (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 66.0,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 10.83
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Mistral Small 3.1 (03/2025)",
+            "company": "Mistral",
+            "accuracy": 65.9,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 1.45
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Mixtral (8x7B)",
+            "company": "Mistral",
+            "accuracy": 64.9,
+            "cost_input": "$0.60",
+            "cost_output": "$0.60",
+            "latency": 1.11
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemini 2.5 Pro Exp",
+            "company": "Google",
+            "accuracy": 64.7,
+            "cost_input": "$1.25",
+            "cost_output": "$10.00",
+            "latency": 8.38
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "DeepSeek V3 (03/24/2025)",
+            "company": "Deepseek",
+            "accuracy": 64.7,
+            "cost_input": "$1.20",
+            "cost_output": "$1.20",
+            "latency": 4.22
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Mistral Small (02/2024)",
+            "company": "Mistral",
+            "accuracy": 64.1,
+            "cost_input": "$0.20",
+            "cost_output": "$0.60",
+            "latency": 1.57
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Qwen 3 (235B)",
+            "company": "Alibaba",
+            "accuracy": 63.6,
+            "cost_input": "$0.22",
+            "cost_output": "$0.88",
+            "latency": 17.6
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Grok 3 Beta",
+            "company": "xAI",
+            "accuracy": 63.5,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 0.81
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemini 2.5 Flash Preview (Nonthinking)",
+            "company": "Google",
+            "accuracy": 63.4,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": 0.82
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 3.1 Instruct Turbo (8B)",
+            "company": "Meta",
+            "accuracy": 63.4,
+            "cost_input": "$0.18",
+            "cost_output": "$0.18",
+            "latency": 0.92
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Grok 3 Mini Fast High Reasoning",
+            "company": "xAI",
+            "accuracy": 63.4,
+            "cost_input": "$0.60",
+            "cost_output": "$4.00",
+            "latency": 7.5
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 4 Maverick",
+            "company": "Meta",
+            "accuracy": 63.3,
+            "cost_input": "$0.27",
+            "cost_output": "$0.85",
+            "latency": 2.24
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Mistral (7B)",
+            "company": "Mistral",
+            "accuracy": 63.0,
+            "cost_input": "$0.18",
+            "cost_output": "$0.18",
+            "latency": 0.87
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 3 (8B)",
+            "company": "Meta",
+            "accuracy": 62.7,
+            "cost_input": "$0.20",
+            "cost_output": "$0.20",
+            "latency": 0.57
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Qwen 2.5 Instruct Turbo (7B)",
+            "company": "Alibaba",
+            "accuracy": 62.6,
+            "cost_input": "$0.30",
+            "cost_output": "$0.30",
+            "latency": 0.78
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "DeepSeek R1",
+            "company": "Deepseek",
+            "accuracy": 62.0,
+            "cost_input": "$8.00",
+            "cost_output": "$8.00",
+            "latency": 30.54
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Jamba 1.5 Large",
+            "company": "Ai21 Labs",
+            "accuracy": 61.9,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 3.15
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 4 Scout",
+            "company": "Meta",
+            "accuracy": 61.8,
+            "cost_input": "$0.18",
+            "cost_output": "$0.59",
+            "latency": 2.14
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "GPT 4o (2024-08-06)",
+            "company": "Openai",
+            "accuracy": 61.7,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 1.32
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "GPT 3.5",
+            "company": "Openai",
+            "accuracy": 61.6,
+            "cost_input": "$0.50",
+            "cost_output": "$1.50",
+            "latency": 1.09
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Jamba 1.6 Large",
+            "company": "Ai21 Labs",
+            "accuracy": 61.2,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 2.54
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemini 2.5 Flash Preview (Thinking)",
+            "company": "Google",
+            "accuracy": 60.6,
+            "cost_input": "$0.15",
+            "cost_output": "$3.50",
+            "latency": 5.08
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemma 2 (27B)",
+            "company": "Google",
+            "accuracy": 59.9,
+            "cost_input": "$0.50",
+            "cost_output": "$0.50",
+            "latency": 2.21
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 2 (70B)",
+            "company": "Meta",
+            "accuracy": 59.7,
+            "cost_input": "$0.90",
+            "cost_output": "$0.90",
+            "latency": 1.39
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemma 2 (9B)",
+            "company": "Google",
+            "accuracy": 59.6,
+            "cost_input": "$0.20",
+            "cost_output": "$0.20",
+            "latency": 0.91
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Grok 2",
+            "company": "xAI",
+            "accuracy": 58.0,
+            "cost_input": "$2.00",
+            "cost_output": "$10.00",
+            "latency": 1.06
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Jamba 1.5 Mini",
+            "company": "Ai21 Labs",
+            "accuracy": 56.2,
+            "cost_input": "$0.20",
+            "cost_output": "$0.40",
+            "latency": 0.52
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 2 (13B)",
+            "company": "Meta",
+            "accuracy": 55.9,
+            "cost_input": "$0.20",
+            "cost_output": "$0.20",
+            "latency": 1.47
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "GPT 4.1 Nano",
+            "company": "Openai",
+            "accuracy": 54.8,
+            "cost_input": "$0.10",
+            "cost_output": "$0.40",
+            "latency": 0.6
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "DBRX Instruct",
+            "company": "Databricks",
+            "accuracy": 48.0,
+            "cost_input": "$2.25",
+            "cost_output": "$6.75",
+            "latency": 1.26
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 2 (7B)",
+            "company": "Meta",
+            "accuracy": 42.5,
+            "cost_input": "$0.20",
+            "cost_output": "$0.20",
+            "latency": 0.8
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemini 2.5 Pro Exp",
+            "company": "Google",
+            "accuracy": 83.6,
+            "cost_input": "$1.25",
+            "cost_output": "$10.00",
+            "latency": 3.51
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemini 2.5 Flash Preview (Nonthinking)",
+            "company": "Google",
+            "accuracy": 82.8,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": 0.43
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "o3",
+            "company": "Openai",
+            "accuracy": 82.5,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 5.14
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Grok 3 Mini Fast High Reasoning",
+            "company": "xAI",
+            "accuracy": 82.0,
+            "cost_input": "$0.60",
+            "cost_output": "$4.00",
+            "latency": 4.92
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Grok 3 Beta",
+            "company": "xAI",
+            "accuracy": 82.0,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 0.44
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "GPT 4.1",
+            "company": "Openai",
+            "accuracy": 81.9,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 0.42
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemini 2.5 Flash Preview (Thinking)",
+            "company": "Google",
+            "accuracy": 81.8,
+            "cost_input": "$0.15",
+            "cost_output": "$3.50",
+            "latency": 2.66
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "o1 Preview",
+            "company": "Openai",
+            "accuracy": 81.7,
+            "cost_input": "$15.00",
+            "cost_output": "$60.00",
+            "latency": 10.33
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Grok 3 Mini Fast Low Reasoning",
+            "company": "xAI",
+            "accuracy": 81.6,
+            "cost_input": "$0.60",
+            "cost_output": "$4.00",
+            "latency": 3.38
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude Opus 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 81.6,
+            "cost_input": "$15.00",
+            "cost_output": "$75.00",
+            "latency": 3.39
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude Sonnet 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 81.5,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 4.68
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude Sonnet 4 (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 81.3,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 10.79
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "DeepSeek V3",
+            "company": "Deepseek",
+            "accuracy": 80.1,
+            "cost_input": "$0.90",
+            "cost_output": "$0.90",
+            "latency": 4.13
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "DeepSeek V3 (03/24/2025)",
+            "company": "Deepseek",
+            "accuracy": 79.9,
+            "cost_input": "$1.20",
+            "cost_output": "$1.20",
+            "latency": 7.33
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "GPT 4o (2024-11-20)",
+            "company": "Openai",
+            "accuracy": 79.8,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 0.35
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemini 2.0 Flash (001)",
+            "company": "Google",
+            "accuracy": 79.7,
+            "cost_input": "$0.10",
+            "cost_output": "$0.40",
+            "latency": 0.34
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude 3.7 Sonnet (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 79.3,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 6.6
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Qwen 2.5 Instruct Turbo (72B)",
+            "company": "Alibaba",
+            "accuracy": 79.2,
+            "cost_input": "$1.20",
+            "cost_output": "$1.20",
+            "latency": 0.62
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Qwen 3 (235B)",
+            "company": "Alibaba",
+            "accuracy": 79.2,
+            "cost_input": "$0.22",
+            "cost_output": "$0.88",
+            "latency": 11.58
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "o4 Mini",
+            "company": "Openai",
+            "accuracy": 79.0,
+            "cost_input": "$1.10",
+            "cost_output": "$4.40",
+            "latency": 3.66
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 3.1 Instruct Turbo (405B)",
+            "company": "Meta",
+            "accuracy": 79.0,
+            "cost_input": "$3.50",
+            "cost_output": "$3.50",
+            "latency": 0.81
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "GPT 4o (2024-08-06)",
+            "company": "Openai",
+            "accuracy": 79.0,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 0.39
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude 3.5 Sonnet Latest",
+            "company": "Anthropic",
+            "accuracy": 78.8,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 0.83
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Command A",
+            "company": "Cohere",
+            "accuracy": 78.7,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 0.71
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "o1 Mini",
+            "company": "Openai",
+            "accuracy": 78.7,
+            "cost_input": "$3.00",
+            "cost_output": "$12.00",
+            "latency": 3.81
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 3.1 Instruct Turbo (70B)",
+            "company": "Meta",
+            "accuracy": 78.2,
+            "cost_input": "$0.88",
+            "cost_output": "$0.88",
+            "latency": 3.01
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude 3.7 Sonnet (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 78.1,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 1.13
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 3.3 Instruct Turbo (70B)",
+            "company": "Meta",
+            "accuracy": 78.0,
+            "cost_input": "$0.88",
+            "cost_output": "$0.88",
+            "latency": 0.56
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "GPT 4 Turbo",
+            "company": "Openai",
+            "accuracy": 78.0,
+            "cost_input": "$10.00",
+            "cost_output": "$30.00",
+            "latency": 1.01
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude 3.5 Sonnet",
+            "company": "Anthropic",
+            "accuracy": 77.6,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 1.4
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "o1",
+            "company": "Openai",
+            "accuracy": 77.6,
+            "cost_input": "$15.00",
+            "cost_output": "$60.00",
+            "latency": 8.47
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude 3 Opus",
+            "company": "Anthropic",
+            "accuracy": 77.5,
+            "cost_input": "$15.00",
+            "cost_output": "$75.00",
+            "latency": 4.61
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 4 Maverick",
+            "company": "Meta",
+            "accuracy": 77.2,
+            "cost_input": "$0.27",
+            "cost_output": "$0.85",
+            "latency": 0.28
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "GPT 4.1 Mini",
+            "company": "Openai",
+            "accuracy": 76.8,
+            "cost_input": "$0.40",
+            "cost_output": "$1.60",
+            "latency": 0.41
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "GPT 4o Mini",
+            "company": "Openai",
+            "accuracy": 76.2,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": 0.4
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Jamba 1.5 Large",
+            "company": "Ai21 Labs",
+            "accuracy": 74.8,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 0.73
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemini 1.5 Pro (001)",
+            "company": "Google",
+            "accuracy": 74.4,
+            "cost_input": "$1.25",
+            "cost_output": "$5.00",
+            "latency": 1.54
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Jamba 1.6 Large",
+            "company": "Ai21 Labs",
+            "accuracy": 74.1,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 0.65
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemini 1.0 Pro 002",
+            "company": "Google",
+            "accuracy": 73.4,
+            "cost_input": "$0.50",
+            "cost_output": "$1.50",
+            "latency": 0.44
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude 3.5 Haiku Latest",
+            "company": "Anthropic",
+            "accuracy": 73.0,
+            "cost_input": "$1.00",
+            "cost_output": "$5.00",
+            "latency": 1.0
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Qwen 2.5 Instruct Turbo (7B)",
+            "company": "Alibaba",
+            "accuracy": 72.4,
+            "cost_input": "$0.30",
+            "cost_output": "$0.30",
+            "latency": 0.33
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude 3 Sonnet",
+            "company": "Anthropic",
+            "accuracy": 72.3,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 1.98
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 4 Scout",
+            "company": "Meta",
+            "accuracy": 71.8,
+            "cost_input": "$0.18",
+            "cost_output": "$0.59",
+            "latency": 0.23
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemini 1.5 Pro (002)",
+            "company": "Google",
+            "accuracy": 71.6,
+            "cost_input": "$1.25",
+            "cost_output": "$5.00",
+            "latency": 0.62
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Mistral Small 3.1 (03/2025)",
+            "company": "Mistral",
+            "accuracy": 70.9,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 0.41
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "o3 Mini",
+            "company": "Openai",
+            "accuracy": 70.9,
+            "cost_input": "$1.10",
+            "cost_output": "$4.40",
+            "latency": 9.8
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Command R+",
+            "company": "Cohere",
+            "accuracy": 70.5,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 0.27
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemma 2 (9B)",
+            "company": "Google",
+            "accuracy": 70.0,
+            "cost_input": "$0.20",
+            "cost_output": "$0.20",
+            "latency": 0.43
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "DeepSeek R1",
+            "company": "Deepseek",
+            "accuracy": 69.9,
+            "cost_input": "$8.00",
+            "cost_output": "$8.00",
+            "latency": 18.66
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Jamba 1.6 Mini",
+            "company": "Ai21 Labs",
+            "accuracy": 69.7,
+            "cost_input": "$0.20",
+            "cost_output": "$0.40",
+            "latency": 0.27
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Command",
+            "company": "Cohere",
+            "accuracy": 68.8,
+            "cost_input": "$1.00",
+            "cost_output": "$2.00",
+            "latency": 2.0
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Jamba 1.5 Mini",
+            "company": "Ai21 Labs",
+            "accuracy": 68.1,
+            "cost_input": "$0.20",
+            "cost_output": "$0.40",
+            "latency": 0.25
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemma 2 (27B)",
+            "company": "Google",
+            "accuracy": 65.5,
+            "cost_input": "$0.50",
+            "cost_output": "$0.50",
+            "latency": 0.59
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "GPT 3.5",
+            "company": "Openai",
+            "accuracy": 64.8,
+            "cost_input": "$0.50",
+            "cost_output": "$1.50",
+            "latency": 0.48
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemini 1.5 Flash (002)",
+            "company": "Google",
+            "accuracy": 62.0,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 0.41
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Mistral Medium 3.1 (05/2025)",
+            "company": "Mistral",
+            "accuracy": 61.3,
+            "cost_input": "$0.40",
+            "cost_output": "$2.00",
+            "latency": 0.43
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 2 (70B)",
+            "company": "Meta",
+            "accuracy": 59.4,
+            "cost_input": "$0.90",
+            "cost_output": "$0.90",
+            "latency": 13.08
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "GPT 4.1 Nano",
+            "company": "Openai",
+            "accuracy": 58.3,
+            "cost_input": "$0.10",
+            "cost_output": "$0.40",
+            "latency": 0.34
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Mixtral (8x7B)",
+            "company": "Mistral",
+            "accuracy": 53.3,
+            "cost_input": "$0.60",
+            "cost_output": "$0.60",
+            "latency": 13.81
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 3.1 Instruct Turbo (8B)",
+            "company": "Meta",
+            "accuracy": 52.5,
+            "cost_input": "$0.18",
+            "cost_output": "$0.18",
+            "latency": 0.56
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 2 (13B)",
+            "company": "Meta",
+            "accuracy": 51.6,
+            "cost_input": "$0.20",
+            "cost_output": "$0.20",
+            "latency": 1.35
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Mistral (7B)",
+            "company": "Mistral",
+            "accuracy": 51.0,
+            "cost_input": "$0.18",
+            "cost_output": "$0.18",
+            "latency": 1.95
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Falcon (40B)",
+            "company": "Technology Innovation Institute",
+            "accuracy": 50.9,
+            "cost_input": "$0.80",
+            "cost_output": "$0.80",
+            "latency": 5.05
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 2 (7B)",
+            "company": "Meta",
+            "accuracy": 49.3,
+            "cost_input": "$0.20",
+            "cost_output": "$0.20",
+            "latency": 0.85
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Falcon (7B)",
+            "company": "Technology Innovation Institute",
+            "accuracy": 47.1,
+            "cost_input": "$0.20",
+            "cost_output": "$0.20",
+            "latency": 1.24
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "DBRX Instruct",
+            "company": "Databricks",
+            "accuracy": 35.6,
+            "cost_input": "$2.25",
+            "cost_output": "$6.75",
+            "latency": 0.82
+        },
+        {
+            "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Command R",
+            "company": "Cohere",
+            "accuracy": 35.0,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": 0.19
+        },
+        {
+            "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
+            "model": "o3",
+            "company": "Openai",
+            "accuracy": 48.3,
+            "cost_input": "$0.74",
+            "cost_output": "N/A",
+            "latency": 180.18
+        },
+        {
+            "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
+            "model": "Claude Sonnet 4 (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 44.5,
+            "cost_input": "$0.85",
+            "cost_output": "N/A",
+            "latency": 136.75
+        },
+        {
+            "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
+            "model": "Claude 3.7 Sonnet (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 44.1,
+            "cost_input": "$1.05",
+            "cost_output": "N/A",
+            "latency": 156.21
+        },
+        {
+            "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
+            "model": "Claude Sonnet 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 43.5,
+            "cost_input": "$0.89",
+            "cost_output": "N/A",
+            "latency": 105.2
+        },
+        {
+            "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
+            "model": "Claude 3.7 Sonnet (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 42.9,
+            "cost_input": "$0.99",
+            "cost_output": "N/A",
+            "latency": 124.6
+        },
+        {
+            "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
+            "model": "o4 Mini",
+            "company": "Openai",
+            "accuracy": 36.5,
+            "cost_input": "$0.28",
+            "cost_output": "N/A",
+            "latency": 162.14
+        },
+        {
+            "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
+            "model": "Grok 3 Mini Fast High Reasoning",
+            "company": "xAI",
+            "accuracy": 31.7,
+            "cost_input": "$0.13",
+            "cost_output": "N/A",
+            "latency": 270.68
+        },
+        {
+            "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
+            "model": "Gemini 2.5 Pro Preview",
+            "company": "Google",
+            "accuracy": 29.4,
+            "cost_input": "$0.22",
+            "cost_output": "N/A",
+            "latency": 80.21
+        },
+        {
+            "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
+            "model": "GPT 4.1",
+            "company": "Openai",
+            "accuracy": 24.6,
+            "cost_input": "$0.24",
+            "cost_output": "N/A",
+            "latency": 66.47
+        },
+        {
+            "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
+            "model": "Grok 3 Beta",
+            "company": "xAI",
+            "accuracy": 24.1,
+            "cost_input": "$0.44",
+            "cost_output": "N/A",
+            "latency": 64.48
+        },
+        {
+            "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
+            "model": "GPT 4.1 Mini",
+            "company": "Openai",
+            "accuracy": 20.8,
+            "cost_input": "$0.07",
+            "cost_output": "N/A",
+            "latency": 50.11
+        },
+        {
+            "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
+            "model": "o1",
+            "company": "Openai",
+            "accuracy": 20.8,
+            "cost_input": "$1.44",
+            "cost_output": "N/A",
+            "latency": 421.83
+        },
+        {
+            "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
+            "model": "GPT 4o (2024-08-06)",
+            "company": "Openai",
+            "accuracy": 19.3,
+            "cost_input": "$0.26",
+            "cost_output": "N/A",
+            "latency": 43.41
+        },
+        {
+            "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
+            "model": "Grok 3 Mini Fast Low Reasoning",
+            "company": "xAI",
+            "accuracy": 17.1,
+            "cost_input": "$0.07",
+            "cost_output": "N/A",
+            "latency": 79.49
+        },
+        {
+            "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
+            "model": "Claude 3.5 Haiku Latest",
+            "company": "Anthropic",
+            "accuracy": 14.3,
+            "cost_input": "$0.07",
+            "cost_output": "N/A",
+            "latency": 46.6
+        },
+        {
+            "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
+            "model": "Gemini 2.0 Flash (001)",
+            "company": "Google",
+            "accuracy": 13.2,
+            "cost_input": "$0.01",
+            "cost_output": "N/A",
+            "latency": 26.16
+        },
+        {
+            "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
+            "model": "o3 Mini",
+            "company": "Openai",
+            "accuracy": 12.7,
+            "cost_input": "$0.04",
+            "cost_output": "N/A",
+            "latency": 146.86
+        },
+        {
+            "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
+            "model": "GPT 4o Mini",
+            "company": "Openai",
+            "accuracy": 10.8,
+            "cost_input": "$0.04",
+            "cost_output": "N/A",
+            "latency": 96.03
+        },
+        {
+            "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
+            "model": "Mistral Small 3.1 (03/2025)",
+            "company": "Mistral",
+            "accuracy": 10.0,
+            "cost_input": "$0.01",
+            "cost_output": "N/A",
+            "latency": 44.56
+        },
+        {
+            "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
+            "model": "Command A",
+            "company": "Cohere",
+            "accuracy": 4.3,
+            "cost_input": "$0.58",
+            "cost_output": "N/A",
+            "latency": 100.95
+        },
+        {
+            "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
+            "model": "Llama 4 Maverick",
+            "company": "Meta",
+            "accuracy": 3.6,
+            "cost_input": "$0.00",
+            "cost_output": "N/A",
+            "latency": 10.21
+        },
+        {
+            "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
+            "model": "Llama 3.3 Instruct Turbo (70B)",
+            "company": "Meta",
+            "accuracy": 3.4,
+            "cost_input": "$0.00",
+            "cost_output": "N/A",
+            "latency": 3.5
+        },
+        {
+            "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
+            "model": "GPT 4.1 Nano",
+            "company": "Openai",
+            "accuracy": 2.5,
+            "cost_input": "$0.00",
+            "cost_output": "N/A",
+            "latency": 63.48
+        },
+        {
+            "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
+            "model": "Jamba 1.6 Mini",
+            "company": "Ai21 Labs",
+            "accuracy": 1.7,
+            "cost_input": "$0.04",
+            "cost_output": "N/A",
+            "latency": 36.01
         }
     ]
 }

--- a/benchmarks_data.json
+++ b/benchmarks_data.json
@@ -1,8 +1,9 @@
 {
-    "timestamp_utc": "2025-06-16 00:29:42",
+    "timestamp_utc": "2025-06-16 01:13:48",
     "benchmarks": [
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "Gemini 2.5 Pro Exp",
             "company": "Google",
             "accuracy": 95.2,
@@ -12,6 +13,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "o3",
             "company": "Openai",
             "accuracy": 94.6,
@@ -21,6 +23,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "Qwen 3 (235B)",
             "company": "Alibaba",
             "accuracy": 94.6,
@@ -30,6 +33,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "Grok 3 Mini Fast High Reasoning",
             "company": "xAI",
             "accuracy": 94.2,
@@ -39,6 +43,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "o4 Mini",
             "company": "Openai",
             "accuracy": 94.2,
@@ -48,6 +53,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "Claude Sonnet 4 (Thinking)",
             "company": "Anthropic",
             "accuracy": 93.8,
@@ -57,6 +63,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "DeepSeek R1",
             "company": "Deepseek",
             "accuracy": 92.2,
@@ -66,6 +73,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "o3 Mini",
             "company": "Openai",
             "accuracy": 91.8,
@@ -75,6 +83,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "Gemini 2.5 Flash Preview (Thinking)",
             "company": "Google",
             "accuracy": 91.8,
@@ -84,6 +93,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "Claude 3.7 Sonnet (Thinking)",
             "company": "Anthropic",
             "accuracy": 91.6,
@@ -93,6 +103,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "Gemini 2.5 Flash Preview (Nonthinking)",
             "company": "Google",
             "accuracy": 91.6,
@@ -102,6 +113,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "o1",
             "company": "Openai",
             "accuracy": 90.4,
@@ -111,6 +123,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "Claude Opus 4 (Nonthinking)",
             "company": "Anthropic",
             "accuracy": 90.4,
@@ -120,6 +133,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "Claude Sonnet 4 (Nonthinking)",
             "company": "Anthropic",
             "accuracy": 90.3,
@@ -129,6 +143,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "Grok 3 Beta",
             "company": "xAI",
             "accuracy": 89.8,
@@ -138,6 +153,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "DeepSeek V3 (03/24/2025)",
             "company": "Deepseek",
             "accuracy": 88.6,
@@ -147,6 +163,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "Gemini 2.0 Flash (001)",
             "company": "Google",
             "accuracy": 88.0,
@@ -156,6 +173,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "GPT 4.1 Mini",
             "company": "Openai",
             "accuracy": 88.0,
@@ -165,6 +183,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "GPT 4.1",
             "company": "Openai",
             "accuracy": 87.2,
@@ -174,6 +193,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "Mistral Medium 3.1 (05/2025)",
             "company": "Mistral",
             "accuracy": 87.0,
@@ -183,6 +203,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "Llama 4 Maverick",
             "company": "Meta",
             "accuracy": 85.2,
@@ -192,6 +213,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "Gemini 2.0 Flash Thinking Exp",
             "company": "Google",
             "accuracy": 84.6,
@@ -201,6 +223,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "Gemini 1.5 Pro (002)",
             "company": "Google",
             "accuracy": 82.8,
@@ -210,6 +233,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "DeepSeek V3",
             "company": "Deepseek",
             "accuracy": 80.4,
@@ -219,6 +243,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "GPT 4.1 Nano",
             "company": "Openai",
             "accuracy": 80.2,
@@ -228,6 +253,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "Llama 4 Scout",
             "company": "Meta",
             "accuracy": 79.2,
@@ -237,6 +263,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "Gemini 1.5 Flash (002)",
             "company": "Google",
             "accuracy": 78.8,
@@ -246,6 +273,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "Grok 2",
             "company": "xAI",
             "accuracy": 78.4,
@@ -255,6 +283,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "Claude 3.7 Sonnet (Nonthinking)",
             "company": "Anthropic",
             "accuracy": 76.8,
@@ -264,6 +293,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "Command A",
             "company": "Cohere",
             "accuracy": 76.2,
@@ -273,6 +303,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "GPT 4o (2024-08-06)",
             "company": "Openai",
             "accuracy": 75.2,
@@ -282,6 +313,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "Mistral Large (11/2024)",
             "company": "Mistral",
             "accuracy": 74.4,
@@ -291,6 +323,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "GPT 4o (2024-11-20)",
             "company": "Openai",
             "accuracy": 74.0,
@@ -300,6 +333,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "Llama 3.3 Instruct Turbo (70B)",
             "company": "Meta",
             "accuracy": 73.4,
@@ -309,6 +343,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "GPT 4o Mini",
             "company": "Openai",
             "accuracy": 72.6,
@@ -318,6 +353,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "Claude 3.5 Sonnet Latest",
             "company": "Anthropic",
             "accuracy": 72.4,
@@ -327,6 +363,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "Llama 3.1 Instruct Turbo (405B)",
             "company": "Meta",
             "accuracy": 71.4,
@@ -336,6 +373,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "Mistral Small (02/2024)",
             "company": "Mistral",
             "accuracy": 70.6,
@@ -345,6 +383,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "Grok 3 Mini Fast Low Reasoning",
             "company": "xAI",
             "accuracy": 70.2,
@@ -354,6 +393,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "Mistral Small 3.1 (03/2025)",
             "company": "Mistral",
             "accuracy": 68.4,
@@ -363,6 +403,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "Llama 3.1 Instruct Turbo (70B)",
             "company": "Meta",
             "accuracy": 65.0,
@@ -372,6 +413,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "Claude 3.5 Haiku Latest",
             "company": "Anthropic",
             "accuracy": 64.2,
@@ -381,6 +423,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "Jamba 1.6 Large",
             "company": "Ai21 Labs",
             "accuracy": 54.8,
@@ -390,6 +433,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "Llama 3.1 Instruct Turbo (8B)",
             "company": "Meta",
             "accuracy": 44.4,
@@ -399,6 +443,7 @@
         },
         {
             "benchmark": "math500-05-30-2025",
+            "benchmark_group": "Math",
             "model": "Jamba 1.6 Mini",
             "company": "Ai21 Labs",
             "accuracy": 25.4,
@@ -407,3085 +452,8 @@
             "latency": 4.86
         },
         {
-            "benchmark": "medqa-05-30-2025",
-            "model": "o1",
-            "company": "Openai",
-            "accuracy": 96.5,
-            "cost_input": "$15.00",
-            "cost_output": "$60.00",
-            "latency": 11.15
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "o3",
-            "company": "Openai",
-            "accuracy": 96.1,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 8.51
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "o4 Mini",
-            "company": "Openai",
-            "accuracy": 96.0,
-            "cost_input": "$1.10",
-            "cost_output": "$4.40",
-            "latency": 6.6
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "o3 Mini",
-            "company": "Openai",
-            "accuracy": 94.8,
-            "cost_input": "$1.10",
-            "cost_output": "$4.40",
-            "latency": 8.39
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "Gemini 2.5 Pro Exp",
-            "company": "Google",
-            "accuracy": 93.1,
-            "cost_input": "$1.25",
-            "cost_output": "$10.00",
-            "latency": 10.7
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "o1 Preview",
-            "company": "Openai",
-            "accuracy": 93.0,
-            "cost_input": "$15.00",
-            "cost_output": "$60.00",
-            "latency": 16.44
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "Claude Opus 4 (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 92.9,
-            "cost_input": "$15.00",
-            "cost_output": "$75.00",
-            "latency": 11.93
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "Claude Sonnet 4 (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 92.7,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 26.99
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "Grok 2",
-            "company": "xAI",
-            "accuracy": 92.3,
-            "cost_input": "$2.00",
-            "cost_output": "$10.00",
-            "latency": 4.09
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "GPT 4.1",
-            "company": "Openai",
-            "accuracy": 91.2,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 3.08
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "Gemini 2.5 Flash Preview (Thinking)",
-            "company": "Google",
-            "accuracy": 91.0,
-            "cost_input": "$0.15",
-            "cost_output": "$3.50",
-            "latency": 8.87
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "DeepSeek R1",
-            "company": "Deepseek",
-            "accuracy": 90.8,
-            "cost_input": "$8.00",
-            "cost_output": "$8.00",
-            "latency": 41.57
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "Qwen 3 (235B)",
-            "company": "Alibaba",
-            "accuracy": 90.6,
-            "cost_input": "$0.22",
-            "cost_output": "$0.88",
-            "latency": 26.26
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "Claude Sonnet 4 (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 90.3,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 8.71
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "o1 Mini",
-            "company": "Openai",
-            "accuracy": 90.2,
-            "cost_input": "$3.00",
-            "cost_output": "$12.00",
-            "latency": 5.89
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "Claude 3.7 Sonnet (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 90.2,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 15.74
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "Grok 3 Mini Fast High Reasoning",
-            "company": "xAI",
-            "accuracy": 90.1,
-            "cost_input": "$0.60",
-            "cost_output": "$4.00",
-            "latency": 7.06
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "Grok 3 Mini Fast Low Reasoning",
-            "company": "xAI",
-            "accuracy": 88.6,
-            "cost_input": "$0.60",
-            "cost_output": "$4.00",
-            "latency": 4.88
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "Llama 3.1 Instruct Turbo (405B)",
-            "company": "Meta",
-            "accuracy": 88.2,
-            "cost_input": "$3.50",
-            "cost_output": "$3.50",
-            "latency": 8.75
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "GPT 4o (2024-08-06)",
-            "company": "Openai",
-            "accuracy": 88.2,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 3.39
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "Gemini 2.5 Flash Preview (Nonthinking)",
-            "company": "Google",
-            "accuracy": 86.7,
-            "cost_input": "$0.15",
-            "cost_output": "$0.60",
-            "latency": 2.25
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "Llama 3.1 Instruct Turbo (70B)",
-            "company": "Meta",
-            "accuracy": 84.8,
-            "cost_input": "$0.88",
-            "cost_output": "$0.88",
-            "latency": 4.8
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "GPT 4.1 Mini",
-            "company": "Openai",
-            "accuracy": 84.6,
-            "cost_input": "$0.40",
-            "cost_output": "$1.60",
-            "latency": 1.86
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "Grok 3 Beta",
-            "company": "xAI",
-            "accuracy": 83.9,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 7.54
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "Claude 3.5 Sonnet Latest",
-            "company": "Anthropic",
-            "accuracy": 83.2,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 5.92
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "DeepSeek V3 (03/24/2025)",
-            "company": "Deepseek",
-            "accuracy": 82.0,
-            "cost_input": "$1.20",
-            "cost_output": "$1.20",
-            "latency": 12.88
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "GPT 4 Turbo",
-            "company": "Openai",
-            "accuracy": 82.0,
-            "cost_input": "$10.00",
-            "cost_output": "$30.00",
-            "latency": 8.41
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "DeepSeek V3",
-            "company": "Deepseek",
-            "accuracy": 80.9,
-            "cost_input": "$0.90",
-            "cost_output": "$0.90",
-            "latency": 6.82
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "Command A",
-            "company": "Cohere",
-            "accuracy": 80.5,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 2.91
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "Mistral Medium 3.1 (05/2025)",
-            "company": "Mistral",
-            "accuracy": 78.2,
-            "cost_input": "$0.40",
-            "cost_output": "$2.00",
-            "latency": 7.34
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "Qwen 2.5 Instruct Turbo (72B)",
-            "company": "Alibaba",
-            "accuracy": 77.4,
-            "cost_input": "$1.20",
-            "cost_output": "$1.20",
-            "latency": 5.57
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "Gemini 1.5 Pro (002)",
-            "company": "Google",
-            "accuracy": 76.5,
-            "cost_input": "$1.25",
-            "cost_output": "$5.00",
-            "latency": 5.93
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "Mistral Large (11/2024)",
-            "company": "Mistral",
-            "accuracy": 76.2,
-            "cost_input": "$2.00",
-            "cost_output": "$6.00",
-            "latency": 4.86
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "GPT 4o Mini",
-            "company": "Openai",
-            "accuracy": 72.4,
-            "cost_input": "$0.15",
-            "cost_output": "$0.60",
-            "latency": 2.32
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "Mistral Small 3.1 (03/2025)",
-            "company": "Mistral",
-            "accuracy": 69.1,
-            "cost_input": "$0.07",
-            "cost_output": "$0.30",
-            "latency": 3.63
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "GPT 4.1 Nano",
-            "company": "Openai",
-            "accuracy": 68.2,
-            "cost_input": "$0.10",
-            "cost_output": "$0.40",
-            "latency": 1.42
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "Jamba 1.5 Large",
-            "company": "Ai21 Labs",
-            "accuracy": 68.1,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 6.0
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "Llama 3.1 Instruct Turbo (8B)",
-            "company": "Meta",
-            "accuracy": 62.6,
-            "cost_input": "$0.18",
-            "cost_output": "$0.18",
-            "latency": 2.37
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "GPT 3.5",
-            "company": "Openai",
-            "accuracy": 58.5,
-            "cost_input": "$0.50",
-            "cost_output": "$1.50",
-            "latency": 1.59
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "Mistral Small (02/2024)",
-            "company": "Mistral",
-            "accuracy": 57.0,
-            "cost_input": "$0.20",
-            "cost_output": "$0.60",
-            "latency": 2.76
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "Jamba 1.5 Mini",
-            "company": "Ai21 Labs",
-            "accuracy": 55.2,
-            "cost_input": "$0.20",
-            "cost_output": "$0.40",
-            "latency": 1.14
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "Mixtral (8x7B)",
-            "company": "Mistral",
-            "accuracy": 53.2,
-            "cost_input": "$0.60",
-            "cost_output": "$0.60",
-            "latency": 3.49
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "Jamba 1.6 Mini",
-            "company": "Ai21 Labs",
-            "accuracy": 52.5,
-            "cost_input": "$0.20",
-            "cost_output": "$0.40",
-            "latency": 2.19
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "Command R+",
-            "company": "Cohere",
-            "accuracy": 51.4,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 6.06
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "Llama 4 Scout",
-            "company": "Meta",
-            "accuracy": 50.9,
-            "cost_input": "$0.18",
-            "cost_output": "$0.59",
-            "latency": 4.8
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "Jamba 1.6 Large",
-            "company": "Ai21 Labs",
-            "accuracy": 50.7,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 7.31
-        },
-        {
-            "benchmark": "medqa-05-30-2025",
-            "model": "Llama 4 Maverick",
-            "company": "Meta",
-            "accuracy": 43.3,
-            "cost_input": "$0.27",
-            "cost_output": "$0.85",
-            "latency": 7.75
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "o3",
-            "company": "Openai",
-            "accuracy": 79.0,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 25.18
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Grok 3 Beta",
-            "company": "xAI",
-            "accuracy": 78.8,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 13.11
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "o4 Mini",
-            "company": "Openai",
-            "accuracy": 78.8,
-            "cost_input": "$1.10",
-            "cost_output": "$4.40",
-            "latency": 15.25
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "o1",
-            "company": "Openai",
-            "accuracy": 78.6,
-            "cost_input": "$15.00",
-            "cost_output": "$60.00",
-            "latency": 19.19
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Claude 3.7 Sonnet (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 78.4,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 43.26
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "GPT 4.1",
-            "company": "Openai",
-            "accuracy": 78.4,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 8.03
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "GPT 4o (2024-11-20)",
-            "company": "Openai",
-            "accuracy": 78.1,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 5.83
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Gemini 2.5 Pro Exp",
-            "company": "Google",
-            "accuracy": 77.1,
-            "cost_input": "$1.25",
-            "cost_output": "$10.00",
-            "latency": 22.04
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "DeepSeek R1",
-            "company": "Deepseek",
-            "accuracy": 76.7,
-            "cost_input": "$8.00",
-            "cost_output": "$8.00",
-            "latency": 162.88
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Grok 3 Mini Fast Low Reasoning",
-            "company": "xAI",
-            "accuracy": 76.5,
-            "cost_input": "$0.60",
-            "cost_output": "$4.00",
-            "latency": 11.74
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Claude Sonnet 4 (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 75.9,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 31.99
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Claude 3.7 Sonnet (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 75.9,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 6.44
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Claude Opus 4 (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 75.8,
-            "cost_input": "$15.00",
-            "cost_output": "$75.00",
-            "latency": 15.32
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Grok 3 Mini Fast High Reasoning",
-            "company": "xAI",
-            "accuracy": 75.7,
-            "cost_input": "$0.60",
-            "cost_output": "$4.00",
-            "latency": 24.96
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Gemini 2.5 Flash Preview (Nonthinking)",
-            "company": "Google",
-            "accuracy": 75.4,
-            "cost_input": "$0.15",
-            "cost_output": "$0.60",
-            "latency": 5.46
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "DeepSeek V3 (03/24/2025)",
-            "company": "Deepseek",
-            "accuracy": 75.2,
-            "cost_input": "$1.20",
-            "cost_output": "$1.20",
-            "latency": 31.71
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "GPT 4.1 Mini",
-            "company": "Openai",
-            "accuracy": 75.0,
-            "cost_input": "$0.40",
-            "cost_output": "$1.60",
-            "latency": 5.91
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "GPT 4o (2024-08-06)",
-            "company": "Openai",
-            "accuracy": 75.0,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 9.54
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Gemini 2.5 Flash Preview (Thinking)",
-            "company": "Google",
-            "accuracy": 74.7,
-            "cost_input": "$0.15",
-            "cost_output": "$3.50",
-            "latency": 15.37
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Qwen 3 (235B)",
-            "company": "Alibaba",
-            "accuracy": 74.4,
-            "cost_input": "$0.22",
-            "cost_output": "$0.88",
-            "latency": 94.33
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "o3 Mini",
-            "company": "Openai",
-            "accuracy": 73.9,
-            "cost_input": "$1.10",
-            "cost_output": "$4.40",
-            "latency": 81.08
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Gemini 2.0 Flash Thinking Exp",
-            "company": "Google",
-            "accuracy": 73.8,
-            "cost_input": "$0.10",
-            "cost_output": "$0.70",
-            "latency": 12.8
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Claude 3.5 Sonnet Latest",
-            "company": "Anthropic",
-            "accuracy": 73.7,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 5.94
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Claude Sonnet 4 (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 73.5,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 12.18
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Mistral Medium 3.1 (05/2025)",
-            "company": "Mistral",
-            "accuracy": 73.4,
-            "cost_input": "$0.40",
-            "cost_output": "$2.00",
-            "latency": 11.27
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Gemini 2.0 Flash Exp",
-            "company": "Google",
-            "accuracy": 72.4,
-            "cost_input": "$0.07",
-            "cost_output": "$0.30",
-            "latency": 7.51
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "DeepSeek V3",
-            "company": "Deepseek",
-            "accuracy": 72.0,
-            "cost_input": "$0.90",
-            "cost_output": "$0.90",
-            "latency": 25.76
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Grok 2",
-            "company": "xAI",
-            "accuracy": 71.4,
-            "cost_input": "$2.00",
-            "cost_output": "$10.00",
-            "latency": 10.63
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Gemini 2.0 Pro Exp",
-            "company": "Google",
-            "accuracy": 71.0,
-            "cost_input": "$1.25",
-            "cost_output": "$5.00",
-            "latency": 9.14
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Gemini 2.0 Flash (001)",
-            "company": "Google",
-            "accuracy": 70.5,
-            "cost_input": "$0.10",
-            "cost_output": "$0.40",
-            "latency": 5.72
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Llama 4 Maverick",
-            "company": "Meta",
-            "accuracy": 69.3,
-            "cost_input": "$0.27",
-            "cost_output": "$0.85",
-            "latency": 28.18
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Mistral Large (11/2024)",
-            "company": "Mistral",
-            "accuracy": 67.7,
-            "cost_input": "$2.00",
-            "cost_output": "$6.00",
-            "latency": 12.0
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Command A",
-            "company": "Cohere",
-            "accuracy": 66.6,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 10.13
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Llama 3.1 Instruct Turbo (405B)",
-            "company": "Meta",
-            "accuracy": 66.3,
-            "cost_input": "$3.50",
-            "cost_output": "$3.50",
-            "latency": 24.91
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "GPT 4.1 Nano",
-            "company": "Openai",
-            "accuracy": 66.1,
-            "cost_input": "$0.10",
-            "cost_output": "$0.40",
-            "latency": 3.04
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Jamba 1.6 Large",
-            "company": "Ai21 Labs",
-            "accuracy": 65.3,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 16.3
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "GPT 4o Mini",
-            "company": "Openai",
-            "accuracy": 64.9,
-            "cost_input": "$0.15",
-            "cost_output": "$0.60",
-            "latency": 9.0
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Gemini 1.5 Pro (002)",
-            "company": "Google",
-            "accuracy": 64.9,
-            "cost_input": "$1.25",
-            "cost_output": "$5.00",
-            "latency": 9.91
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Llama 3.3 Instruct Turbo (70B)",
-            "company": "Meta",
-            "accuracy": 63.9,
-            "cost_input": "$0.88",
-            "cost_output": "$0.88",
-            "latency": 3.86
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Claude 3.5 Haiku Latest",
-            "company": "Anthropic",
-            "accuracy": 63.0,
-            "cost_input": "$1.00",
-            "cost_output": "$5.00",
-            "latency": 5.0
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Mistral Small 3.1 (03/2025)",
-            "company": "Mistral",
-            "accuracy": 62.9,
-            "cost_input": "$0.07",
-            "cost_output": "$0.30",
-            "latency": 7.95
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Jamba 1.5 Large",
-            "company": "Ai21 Labs",
-            "accuracy": 62.7,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 20.32
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Llama 3.1 Instruct Turbo (70B)",
-            "company": "Meta",
-            "accuracy": 61.1,
-            "cost_input": "$0.88",
-            "cost_output": "$0.88",
-            "latency": 4.39
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Llama 4 Scout",
-            "company": "Meta",
-            "accuracy": 59.0,
-            "cost_input": "$0.18",
-            "cost_output": "$0.59",
-            "latency": 7.09
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Mistral Small (02/2024)",
-            "company": "Mistral",
-            "accuracy": 54.1,
-            "cost_input": "$0.20",
-            "cost_output": "$0.60",
-            "latency": 8.97
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Gemini 1.5 Flash (002)",
-            "company": "Google",
-            "accuracy": 53.4,
-            "cost_input": "$0.07",
-            "cost_output": "$0.30",
-            "latency": 3.74
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Jamba 1.6 Mini",
-            "company": "Ai21 Labs",
-            "accuracy": 50.3,
-            "cost_input": "$0.20",
-            "cost_output": "$0.40",
-            "latency": 4.39
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Jamba 1.5 Mini",
-            "company": "Ai21 Labs",
-            "accuracy": 46.9,
-            "cost_input": "$0.20",
-            "cost_output": "$0.40",
-            "latency": 4.82
-        },
-        {
-            "benchmark": "tax_eval_v2-05-30-2025",
-            "model": "Llama 3.1 Instruct Turbo (8B)",
-            "company": "Meta",
-            "accuracy": 39.0,
-            "cost_input": "$0.18",
-            "cost_output": "$0.18",
-            "latency": 2.45
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "GPT 4.1",
-            "company": "Openai",
-            "accuracy": 71.2,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 10.33
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "o3",
-            "company": "Openai",
-            "accuracy": 71.0,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 19.13
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "o4 Mini",
-            "company": "Openai",
-            "accuracy": 70.1,
-            "cost_input": "$1.10",
-            "cost_output": "$4.40",
-            "latency": 17.5
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "Grok 3 Beta",
-            "company": "xAI",
-            "accuracy": 69.1,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 23.86
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "Grok 3 Mini Fast High Reasoning",
-            "company": "xAI",
-            "accuracy": 68.6,
-            "cost_input": "$0.60",
-            "cost_output": "$4.00",
-            "latency": 14.12
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "Gemini 2.5 Pro Exp",
-            "company": "Google",
-            "accuracy": 68.4,
-            "cost_input": "$1.25",
-            "cost_output": "$10.00",
-            "latency": 17.99
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "Claude 3.7 Sonnet (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 68.0,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 22.33
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "Claude Sonnet 4 (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 67.3,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 227.37
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "Grok 3 Mini Fast Low Reasoning",
-            "company": "xAI",
-            "accuracy": 66.0,
-            "cost_input": "$0.60",
-            "cost_output": "$4.00",
-            "latency": 10.42
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "GPT 4.1 Mini",
-            "company": "Openai",
-            "accuracy": 65.8,
-            "cost_input": "$0.40",
-            "cost_output": "$1.60",
-            "latency": 6.56
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "DeepSeek R1",
-            "company": "Deepseek",
-            "accuracy": 63.2,
-            "cost_input": "$8.00",
-            "cost_output": "$8.00",
-            "latency": 46.8
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "Gemini 2.5 Flash Preview (Nonthinking)",
-            "company": "Google",
-            "accuracy": 62.6,
-            "cost_input": "$0.15",
-            "cost_output": "$0.60",
-            "latency": 8.67
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "DeepSeek V3 (03/24/2025)",
-            "company": "Deepseek",
-            "accuracy": 60.9,
-            "cost_input": "$1.20",
-            "cost_output": "$1.20",
-            "latency": 36.59
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "DeepSeek V3",
-            "company": "Deepseek",
-            "accuracy": 60.7,
-            "cost_input": "$0.90",
-            "cost_output": "$0.90",
-            "latency": 28.88
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "Claude 3.5 Sonnet Latest",
-            "company": "Anthropic",
-            "accuracy": 60.5,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": null
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "Claude Sonnet 4 (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 59.9,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 162.67
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "Claude 3.5 Haiku Latest",
-            "company": "Anthropic",
-            "accuracy": 58.2,
-            "cost_input": "$1.00",
-            "cost_output": "$5.00",
-            "latency": null
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "Grok 2",
-            "company": "xAI",
-            "accuracy": 58.2,
-            "cost_input": "$2.00",
-            "cost_output": "$10.00",
-            "latency": 84.8
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "Mistral Medium 3.1 (05/2025)",
-            "company": "Mistral",
-            "accuracy": 58.1,
-            "cost_input": "$0.40",
-            "cost_output": "$2.00",
-            "latency": 30.56
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "Llama 4 Maverick",
-            "company": "Meta",
-            "accuracy": 57.6,
-            "cost_input": "$0.27",
-            "cost_output": "$0.85",
-            "latency": 6.59
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "GPT 4o (2024-11-20)",
-            "company": "Openai",
-            "accuracy": 56.6,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 6.35
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "o3 Mini",
-            "company": "Openai",
-            "accuracy": 55.7,
-            "cost_input": "$1.10",
-            "cost_output": "$4.40",
-            "latency": 31.42
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "GPT 4o Mini",
-            "company": "Openai",
-            "accuracy": 55.0,
-            "cost_input": "$0.15",
-            "cost_output": "$0.60",
-            "latency": null
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "Command A",
-            "company": "Cohere",
-            "accuracy": 54.5,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 14.34
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "Llama 4 Scout",
-            "company": "Meta",
-            "accuracy": 53.9,
-            "cost_input": "$0.18",
-            "cost_output": "$0.59",
-            "latency": 9.22
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "Mistral Small 3.1 (03/2025)",
-            "company": "Mistral",
-            "accuracy": 53.2,
-            "cost_input": "$0.07",
-            "cost_output": "$0.30",
-            "latency": 12.25
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "Gemini 2.0 Pro Exp",
-            "company": "Google",
-            "accuracy": 53.1,
-            "cost_input": "$1.25",
-            "cost_output": "$5.00",
-            "latency": 18.13
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "GPT 4.1 Nano",
-            "company": "Openai",
-            "accuracy": 52.4,
-            "cost_input": "$0.10",
-            "cost_output": "$0.40",
-            "latency": 12.47
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "Jamba 1.6 Large",
-            "company": "Ai21 Labs",
-            "accuracy": 50.7,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 29.61
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "Gemini 1.5 Pro (002)",
-            "company": "Google",
-            "accuracy": 50.3,
-            "cost_input": "$1.25",
-            "cost_output": "$5.00",
-            "latency": 37.35
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "GPT 4o (2024-08-06)",
-            "company": "Openai",
-            "accuracy": 49.3,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": null
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "Llama 3.1 Instruct Turbo (70B)",
-            "company": "Meta",
-            "accuracy": 47.2,
-            "cost_input": "$0.88",
-            "cost_output": "$0.88",
-            "latency": null
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "Jamba 1.5 Large",
-            "company": "Ai21 Labs",
-            "accuracy": 46.6,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 10.74
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "Gemini 1.5 Flash (002)",
-            "company": "Google",
-            "accuracy": 46.6,
-            "cost_input": "$0.07",
-            "cost_output": "$0.30",
-            "latency": 28.38
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "Jamba 1.6 Mini",
-            "company": "Ai21 Labs",
-            "accuracy": 46.0,
-            "cost_input": "$0.20",
-            "cost_output": "$0.40",
-            "latency": 4.28
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "Llama 3.1 Instruct Turbo (8B)",
-            "company": "Meta",
-            "accuracy": 43.5,
-            "cost_input": "$0.18",
-            "cost_output": "$0.18",
-            "latency": null
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "Jamba 1.5 Mini",
-            "company": "Ai21 Labs",
-            "accuracy": 39.9,
-            "cost_input": "$0.20",
-            "cost_output": "$0.40",
-            "latency": 2.34
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "Gemini 2.0 Flash (001)",
-            "company": "Google",
-            "accuracy": 38.5,
-            "cost_input": "$0.10",
-            "cost_output": "$0.40",
-            "latency": 31.35
-        },
-        {
-            "benchmark": "corp_fin_v2-05-30-2025",
-            "model": "Gemini 1.5 Flash (001)",
-            "company": "Google",
-            "accuracy": 32.9,
-            "cost_input": "$0.07",
-            "cost_output": "$0.30",
-            "latency": null
-        },
-        {
-            "benchmark": "swebench-2025-06-13",
-            "model": "Claude Sonnet 4 (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 65.0,
-            "cost_input": "$1.24",
-            "cost_output": "N/A",
-            "latency": 426.52
-        },
-        {
-            "benchmark": "swebench-2025-06-13",
-            "model": "o3",
-            "company": "Openai",
-            "accuracy": 49.8,
-            "cost_input": "$1.42",
-            "cost_output": "N/A",
-            "latency": 620.33
-        },
-        {
-            "benchmark": "swebench-2025-06-13",
-            "model": "GPT 4.1",
-            "company": "Openai",
-            "accuracy": 47.4,
-            "cost_input": "$0.45",
-            "cost_output": "N/A",
-            "latency": 173.98
-        },
-        {
-            "benchmark": "swebench-2025-06-13",
-            "model": "Gemini 2.5 Pro Preview",
-            "company": "Google",
-            "accuracy": 46.8,
-            "cost_input": "$0.88",
-            "cost_output": "N/A",
-            "latency": 540.96
-        },
-        {
-            "benchmark": "swebench-2025-06-13",
-            "model": "Gemini 2.5 Flash Preview (Nonthinking)",
-            "company": "Google",
-            "accuracy": 35.6,
-            "cost_input": "$0.11",
-            "cost_output": "N/A",
-            "latency": 251.91
-        },
-        {
-            "benchmark": "swebench-2025-06-13",
-            "model": "GPT 4.1 Mini",
-            "company": "Openai",
-            "accuracy": 34.8,
-            "cost_input": "$0.13",
-            "cost_output": "N/A",
-            "latency": 233.12
-        },
-        {
-            "benchmark": "swebench-2025-06-13",
-            "model": "o4 Mini",
-            "company": "Openai",
-            "accuracy": 33.4,
-            "cost_input": "$1.54",
-            "cost_output": "N/A",
-            "latency": 976.81
-        },
-        {
-            "benchmark": "swebench-2025-06-13",
-            "model": "GPT 4o (2024-08-06)",
-            "company": "Openai",
-            "accuracy": 27.2,
-            "cost_input": "$1.53",
-            "cost_output": "N/A",
-            "latency": 197.58
-        },
-        {
-            "benchmark": "swebench-2025-06-13",
-            "model": "Llama 4 Maverick",
-            "company": "Meta",
-            "accuracy": 18.4,
-            "cost_input": "$0.12",
-            "cost_output": "N/A",
-            "latency": 62.48
-        },
-        {
-            "benchmark": "swebench-2025-06-13",
-            "model": "Command A",
-            "company": "Cohere",
-            "accuracy": 0.2,
-            "cost_input": "$0.01",
-            "cost_output": "N/A",
-            "latency": 5.26
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "o4 Mini",
-            "company": "Openai",
-            "accuracy": 66.5,
-            "cost_input": "$1.10",
-            "cost_output": "$4.40",
-            "latency": 32.84
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "o3",
-            "company": "Openai",
-            "accuracy": 63.2,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 63.95
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "Claude Opus 4 (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 63.1,
-            "cost_input": "$15.00",
-            "cost_output": "$75.00",
-            "latency": 93.54
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "Gemini 2.5 Pro Preview",
-            "company": "Google",
-            "accuracy": 61.9,
-            "cost_input": "$1.25",
-            "cost_output": "$10.00",
-            "latency": 164.66
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "o3 Mini",
-            "company": "Openai",
-            "accuracy": 59.8,
-            "cost_input": "$1.10",
-            "cost_output": "$4.40",
-            "latency": 53.8
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "DeepSeek R1",
-            "company": "Deepseek",
-            "accuracy": 58.7,
-            "cost_input": "$8.00",
-            "cost_output": "$8.00",
-            "latency": 86.07
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "Grok 3 Mini Fast High Reasoning",
-            "company": "xAI",
-            "accuracy": 57.9,
-            "cost_input": "$0.60",
-            "cost_output": "$4.00",
-            "latency": 213.66
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "Grok 3 Mini Fast Low Reasoning",
-            "company": "xAI",
-            "accuracy": 56.9,
-            "cost_input": "$0.60",
-            "cost_output": "$4.00",
-            "latency": 30.71
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "Claude Opus 4 (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 56.4,
-            "cost_input": "$15.00",
-            "cost_output": "$75.00",
-            "latency": 14.78
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "DeepSeek V3 (03/24/2025)",
-            "company": "Deepseek",
-            "accuracy": 56.0,
-            "cost_input": "$1.20",
-            "cost_output": "$1.20",
-            "latency": 26.93
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "Claude Sonnet 4 (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 55.9,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 42.61
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "Claude 3.7 Sonnet (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 55.1,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 96.47
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "Claude Sonnet 4 (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 53.4,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 14.06
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "Claude 3.7 Sonnet (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 52.8,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 16.23
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "GPT 4.1",
-            "company": "Openai",
-            "accuracy": 50.1,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 30.56
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "Gemini 2.5 Flash Preview (Nonthinking)",
-            "company": "Google",
-            "accuracy": 49.6,
-            "cost_input": "$0.15",
-            "cost_output": "$0.60",
-            "latency": 16.41
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "GPT 4.1 Mini",
-            "company": "Openai",
-            "accuracy": 49.5,
-            "cost_input": "$0.40",
-            "cost_output": "$1.60",
-            "latency": 27.59
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "Grok 3 Beta",
-            "company": "xAI",
-            "accuracy": 47.3,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 5.52
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "Claude 3.5 Sonnet Latest",
-            "company": "Anthropic",
-            "accuracy": 47.1,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 11.04
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "o1",
-            "company": "Openai",
-            "accuracy": 43.6,
-            "cost_input": "$15.00",
-            "cost_output": "$60.00",
-            "latency": 92.08
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "Llama 4 Maverick",
-            "company": "Meta",
-            "accuracy": 43.1,
-            "cost_input": "$0.27",
-            "cost_output": "$0.85",
-            "latency": 9.44
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "Mistral Medium 3.1 (05/2025)",
-            "company": "Mistral",
-            "accuracy": 42.2,
-            "cost_input": "$0.40",
-            "cost_output": "$2.00",
-            "latency": 12.48
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "Gemini 2.0 Flash (001)",
-            "company": "Google",
-            "accuracy": 41.7,
-            "cost_input": "$0.10",
-            "cost_output": "$0.40",
-            "latency": 3.36
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "Claude 3.5 Haiku Latest",
-            "company": "Anthropic",
-            "accuracy": 40.0,
-            "cost_input": "$1.00",
-            "cost_output": "$5.00",
-            "latency": 10.58
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "GPT 4o (2024-11-20)",
-            "company": "Openai",
-            "accuracy": 39.7,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 4.35
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "Gemini 1.5 Pro (002)",
-            "company": "Google",
-            "accuracy": 39.7,
-            "cost_input": "$1.25",
-            "cost_output": "$5.00",
-            "latency": 3.95
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "GPT 4.1 Nano",
-            "company": "Openai",
-            "accuracy": 39.2,
-            "cost_input": "$0.10",
-            "cost_output": "$0.40",
-            "latency": 11.8
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "Gemini 2.5 Flash Preview (Thinking)",
-            "company": "Google",
-            "accuracy": 39.2,
-            "cost_input": "$0.15",
-            "cost_output": "$3.50",
-            "latency": 124.95
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "Grok 2",
-            "company": "xAI",
-            "accuracy": 37.1,
-            "cost_input": "$2.00",
-            "cost_output": "$10.00",
-            "latency": 2.38
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "Llama 4 Scout",
-            "company": "Meta",
-            "accuracy": 36.7,
-            "cost_input": "$0.18",
-            "cost_output": "$0.59",
-            "latency": 16.76
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "Mistral Large (11/2024)",
-            "company": "Mistral",
-            "accuracy": 35.2,
-            "cost_input": "$2.00",
-            "cost_output": "$6.00",
-            "latency": 5.35
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "Gemini 1.5 Flash (002)",
-            "company": "Google",
-            "accuracy": 34.9,
-            "cost_input": "$0.07",
-            "cost_output": "$0.30",
-            "latency": 2.51
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "Llama 3.3 Instruct Turbo (70B)",
-            "company": "Meta",
-            "accuracy": 34.3,
-            "cost_input": "$0.88",
-            "cost_output": "$0.88",
-            "latency": 2.95
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "Command A",
-            "company": "Cohere",
-            "accuracy": 33.0,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 11.75
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "Mistral Small 3.1 (03/2025)",
-            "company": "Mistral",
-            "accuracy": 30.3,
-            "cost_input": "$0.07",
-            "cost_output": "$0.30",
-            "latency": 4.01
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "GPT 4o Mini",
-            "company": "Openai",
-            "accuracy": 25.5,
-            "cost_input": "$0.15",
-            "cost_output": "$0.60",
-            "latency": 7.36
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "Jamba 1.6 Large",
-            "company": "Ai21 Labs",
-            "accuracy": 21.5,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 4.84
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "Command R+",
-            "company": "Cohere",
-            "accuracy": 17.8,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 5.46
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "Mistral Small (02/2024)",
-            "company": "Mistral",
-            "accuracy": 15.3,
-            "cost_input": "$0.20",
-            "cost_output": "$0.60",
-            "latency": 5.04
-        },
-        {
-            "benchmark": "lcb-06-09-2025",
-            "model": "Jamba 1.6 Mini",
-            "company": "Ai21 Labs",
-            "accuracy": 9.8,
-            "cost_input": "$0.20",
-            "cost_output": "$0.40",
-            "latency": 1.14
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "Claude Opus 4 (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 86.1,
-            "cost_input": "$15.00",
-            "cost_output": "$75.00",
-            "latency": 10.41
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "o3",
-            "company": "Openai",
-            "accuracy": 85.6,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 16.74
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "Gemini 2.5 Pro Exp",
-            "company": "Google",
-            "accuracy": 84.1,
-            "cost_input": "$1.25",
-            "cost_output": "$10.00",
-            "latency": 18.46
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "Claude Sonnet 4 (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 83.8,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 47.09
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "o1",
-            "company": "Openai",
-            "accuracy": 83.5,
-            "cost_input": "$15.00",
-            "cost_output": "$60.00",
-            "latency": 26.87
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "Claude 3.7 Sonnet (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 82.7,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 31.74
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "Grok 3 Mini Fast High Reasoning",
-            "company": "xAI",
-            "accuracy": 81.4,
-            "cost_input": "$0.60",
-            "cost_output": "$4.00",
-            "latency": 16.89
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "Claude 3.7 Sonnet (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 80.7,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 6.3
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "o4 Mini",
-            "company": "Openai",
-            "accuracy": 80.6,
-            "cost_input": "$1.10",
-            "cost_output": "$4.40",
-            "latency": 10.44
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "GPT 4.1",
-            "company": "Openai",
-            "accuracy": 80.5,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 8.18
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "Qwen 3 (235B)",
-            "company": "Alibaba",
-            "accuracy": 80.4,
-            "cost_input": "$0.22",
-            "cost_output": "$0.88",
-            "latency": 52.35
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "Grok 3 Mini Fast Low Reasoning",
-            "company": "xAI",
-            "accuracy": 80.0,
-            "cost_input": "$0.60",
-            "cost_output": "$4.00",
-            "latency": 7.43
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "Grok 3 Beta",
-            "company": "xAI",
-            "accuracy": 79.9,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 12.1
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "Claude Sonnet 4 (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 79.4,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 9.71
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "Llama 4 Maverick",
-            "company": "Meta",
-            "accuracy": 79.4,
-            "cost_input": "$0.27",
-            "cost_output": "$0.85",
-            "latency": 6.8
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "DeepSeek V3 (03/24/2025)",
-            "company": "Deepseek",
-            "accuracy": 78.9,
-            "cost_input": "$1.20",
-            "cost_output": "$1.20",
-            "latency": 25.05
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "o3 Mini",
-            "company": "Openai",
-            "accuracy": 78.7,
-            "cost_input": "$1.10",
-            "cost_output": "$4.40",
-            "latency": 22.38
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "Claude 3.5 Sonnet Latest",
-            "company": "Anthropic",
-            "accuracy": 78.4,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 6.29
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "Gemini 2.0 Flash (001)",
-            "company": "Google",
-            "accuracy": 77.4,
-            "cost_input": "$0.10",
-            "cost_output": "$0.40",
-            "latency": 4.32
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "GPT 4.1 Mini",
-            "company": "Openai",
-            "accuracy": 77.2,
-            "cost_input": "$0.40",
-            "cost_output": "$1.60",
-            "latency": 3.83
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "Grok 2",
-            "company": "xAI",
-            "accuracy": 75.5,
-            "cost_input": "$2.00",
-            "cost_output": "$10.00",
-            "latency": 8.75
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "Gemini 1.5 Pro (002)",
-            "company": "Google",
-            "accuracy": 75.3,
-            "cost_input": "$1.25",
-            "cost_output": "$5.00",
-            "latency": 3.34
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "Mistral Medium 3.1 (05/2025)",
-            "company": "Mistral",
-            "accuracy": 74.4,
-            "cost_input": "$0.40",
-            "cost_output": "$2.00",
-            "latency": 8.83
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "GPT 4o (2024-08-06)",
-            "company": "Openai",
-            "accuracy": 74.1,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 9.0
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "DeepSeek V3",
-            "company": "Deepseek",
-            "accuracy": 73.8,
-            "cost_input": "$0.90",
-            "cost_output": "$0.90",
-            "latency": 11.36
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "DeepSeek R1",
-            "company": "Deepseek",
-            "accuracy": 71.1,
-            "cost_input": "$8.00",
-            "cost_output": "$8.00",
-            "latency": 27.28
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "Llama 3.3 Instruct Turbo (70B)",
-            "company": "Meta",
-            "accuracy": 69.9,
-            "cost_input": "$0.88",
-            "cost_output": "$0.88",
-            "latency": 4.18
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "Mistral Large (11/2024)",
-            "company": "Mistral",
-            "accuracy": 69.7,
-            "cost_input": "$2.00",
-            "cost_output": "$6.00",
-            "latency": 7.19
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "Llama 4 Scout",
-            "company": "Meta",
-            "accuracy": 69.6,
-            "cost_input": "$0.18",
-            "cost_output": "$0.59",
-            "latency": 5.34
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "GPT 4o (2024-11-20)",
-            "company": "Openai",
-            "accuracy": 69.1,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 9.14
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "Mistral Small 3.1 (03/2025)",
-            "company": "Mistral",
-            "accuracy": 66.0,
-            "cost_input": "$0.07",
-            "cost_output": "$0.30",
-            "latency": 3.6
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "Gemini 1.5 Flash (002)",
-            "company": "Google",
-            "accuracy": 65.5,
-            "cost_input": "$0.07",
-            "cost_output": "$0.30",
-            "latency": 1.68
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "Command A",
-            "company": "Cohere",
-            "accuracy": 65.2,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 9.85
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "Mistral Small (02/2024)",
-            "company": "Mistral",
-            "accuracy": 64.4,
-            "cost_input": "$0.20",
-            "cost_output": "$0.60",
-            "latency": 4.66
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "Claude 3.5 Haiku Latest",
-            "company": "Anthropic",
-            "accuracy": 64.1,
-            "cost_input": "$1.00",
-            "cost_output": "$5.00",
-            "latency": 5.79
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "GPT 4o Mini",
-            "company": "Openai",
-            "accuracy": 62.7,
-            "cost_input": "$0.15",
-            "cost_output": "$0.60",
-            "latency": 5.09
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "GPT 4.1 Nano",
-            "company": "Openai",
-            "accuracy": 62.3,
-            "cost_input": "$0.10",
-            "cost_output": "$0.40",
-            "latency": 2.4
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "Jamba 1.6 Large",
-            "company": "Ai21 Labs",
-            "accuracy": 49.3,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 9.48
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "Command R+",
-            "company": "Cohere",
-            "accuracy": 43.9,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 4.42
-        },
-        {
-            "benchmark": "mmlu_pro-05-30-2025",
-            "model": "Jamba 1.6 Mini",
-            "company": "Ai21 Labs",
-            "accuracy": 30.2,
-            "cost_input": "$0.20",
-            "cost_output": "$0.40",
-            "latency": 2.43
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "model": "Claude 3.7 Sonnet (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 80.6,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 5.67
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "model": "Claude 3.7 Sonnet (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 79.2,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 13.58
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "model": "GPT 4.1",
-            "company": "Openai",
-            "accuracy": 79.0,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 5.03
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "model": "Gemini 2.5 Pro Exp",
-            "company": "Google",
-            "accuracy": 78.8,
-            "cost_input": "$1.25",
-            "cost_output": "$10.00",
-            "latency": 8.91
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "model": "o3",
-            "company": "Openai",
-            "accuracy": 78.4,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 21.22
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "model": "Claude 3.5 Sonnet Latest",
-            "company": "Anthropic",
-            "accuracy": 78.1,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 4.22
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "model": "GPT 4.1 Mini",
-            "company": "Openai",
-            "accuracy": 77.7,
-            "cost_input": "$0.40",
-            "cost_output": "$1.60",
-            "latency": 4.6
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "model": "o4 Mini",
-            "company": "Openai",
-            "accuracy": 77.1,
-            "cost_input": "$1.10",
-            "cost_output": "$4.40",
-            "latency": 13.0
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "model": "GPT 4o (2024-08-06)",
-            "company": "Openai",
-            "accuracy": 75.2,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 7.36
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "model": "Mistral Small 3.1 (03/2025)",
-            "company": "Mistral",
-            "accuracy": 75.0,
-            "cost_input": "$0.07",
-            "cost_output": "$0.30",
-            "latency": 8.31
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "model": "Claude Sonnet 4 (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 74.6,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 8.42
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "model": "Llama 4 Maverick",
-            "company": "Meta",
-            "accuracy": 72.7,
-            "cost_input": "$0.27",
-            "cost_output": "$0.85",
-            "latency": 2.72
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "model": "Gemini 2.0 Flash (001)",
-            "company": "Google",
-            "accuracy": 72.6,
-            "cost_input": "$0.10",
-            "cost_output": "$0.40",
-            "latency": 3.79
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "model": "GPT 4o (2024-11-20)",
-            "company": "Openai",
-            "accuracy": 72.1,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 5.98
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "model": "Llama 4 Scout",
-            "company": "Meta",
-            "accuracy": 71.7,
-            "cost_input": "$0.18",
-            "cost_output": "$0.59",
-            "latency": 2.43
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "model": "Gemini 1.5 Pro (002)",
-            "company": "Google",
-            "accuracy": 71.0,
-            "cost_input": "$1.25",
-            "cost_output": "$5.00",
-            "latency": 4.2
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "model": "Gemini 2.5 Flash Preview (Nonthinking)",
-            "company": "Google",
-            "accuracy": 70.9,
-            "cost_input": "$0.15",
-            "cost_output": "$0.60",
-            "latency": 3.56
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "model": "Claude Opus 4 (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 70.9,
-            "cost_input": "$15.00",
-            "cost_output": "$75.00",
-            "latency": 13.76
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "model": "Gemini 2.5 Flash Preview (Thinking)",
-            "company": "Google",
-            "accuracy": 69.5,
-            "cost_input": "$0.15",
-            "cost_output": "$3.50",
-            "latency": 8.4
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "model": "GPT 4o Mini",
-            "company": "Openai",
-            "accuracy": 69.2,
-            "cost_input": "$0.15",
-            "cost_output": "$0.60",
-            "latency": 6.06
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "model": "GPT 4.1 Nano",
-            "company": "Openai",
-            "accuracy": 67.0,
-            "cost_input": "$0.10",
-            "cost_output": "$0.40",
-            "latency": 3.86
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "model": "Nova Lite",
-            "company": "Amazon",
-            "accuracy": 66.1,
-            "cost_input": "$0.06",
-            "cost_output": "$0.24",
-            "latency": null
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "model": "Nova Pro",
-            "company": "Amazon",
-            "accuracy": 63.7,
-            "cost_input": "$0.80",
-            "cost_output": "$3.20",
-            "latency": null
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "model": "Claude Sonnet 4 (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 62.5,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 46.32
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "model": "Mistral Medium 3.1 (05/2025)",
-            "company": "Mistral",
-            "accuracy": 60.5,
-            "cost_input": "$0.40",
-            "cost_output": "$2.00",
-            "latency": 7.14
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "model": "Llama 3.2 Vision (90B)",
-            "company": "Meta",
-            "accuracy": 55.0,
-            "cost_input": "$1.20",
-            "cost_output": "$1.20",
-            "latency": 5.07
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "model": "Gemini 1.5 Flash (002)",
-            "company": "Google",
-            "accuracy": 54.6,
-            "cost_input": "$0.07",
-            "cost_output": "$0.30",
-            "latency": 2.1
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "model": "Llama 3.2 Vision (11B)",
-            "company": "Meta",
-            "accuracy": 38.8,
-            "cost_input": "$0.18",
-            "cost_output": "$0.18",
-            "latency": 2.45
-        },
-        {
-            "benchmark": "mortgage_tax-05-30-2025",
-            "model": "Grok 2 Vision",
-            "company": "xAI",
-            "accuracy": 26.7,
-            "cost_input": "$2.00",
-            "cost_output": "$10.00",
-            "latency": null
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "model": "Gemini 2.5 Pro Exp",
-            "company": "Google",
-            "accuracy": 81.5,
-            "cost_input": "$1.25",
-            "cost_output": "$10.00",
-            "latency": 24.15
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "model": "o3",
-            "company": "Openai",
-            "accuracy": 80.1,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 39.27
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "model": "o4 Mini",
-            "company": "Openai",
-            "accuracy": 79.7,
-            "cost_input": "$1.10",
-            "cost_output": "$4.40",
-            "latency": 19.72
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "model": "o1",
-            "company": "Openai",
-            "accuracy": 77.7,
-            "cost_input": "$15.00",
-            "cost_output": "$60.00",
-            "latency": 26.41
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "model": "Claude 3.7 Sonnet (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 76.0,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 69.58
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "model": "Claude Sonnet 4 (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 75.1,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 48.85
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "model": "Claude Opus 4 (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 73.4,
-            "cost_input": "$15.00",
-            "cost_output": "$75.00",
-            "latency": 14.02
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "model": "Llama 4 Maverick",
-            "company": "Meta",
-            "accuracy": 72.6,
-            "cost_input": "$0.27",
-            "cost_output": "$0.85",
-            "latency": 7.91
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "model": "Claude Sonnet 4 (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 72.6,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 10.82
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "model": "Gemini 2.0 Flash (001)",
-            "company": "Google",
-            "accuracy": 71.9,
-            "cost_input": "$0.10",
-            "cost_output": "$0.40",
-            "latency": 45.22
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "model": "Claude 3.7 Sonnet (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 71.6,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 8.32
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "model": "GPT 4.1 Mini",
-            "company": "Openai",
-            "accuracy": 71.1,
-            "cost_input": "$0.40",
-            "cost_output": "$1.60",
-            "latency": 8.23
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "model": "Claude 3.5 Sonnet Latest",
-            "company": "Anthropic",
-            "accuracy": 68.9,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 46.01
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "model": "GPT 4.1",
-            "company": "Openai",
-            "accuracy": 68.9,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 12.0
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "model": "GPT 4o (2024-11-20)",
-            "company": "Openai",
-            "accuracy": 68.1,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 45.87
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "model": "Grok 2 Vision",
-            "company": "xAI",
-            "accuracy": 66.5,
-            "cost_input": "$2.00",
-            "cost_output": "$10.00",
-            "latency": 18.36
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "model": "Llama 4 Scout",
-            "company": "Meta",
-            "accuracy": 66.5,
-            "cost_input": "$0.18",
-            "cost_output": "$0.59",
-            "latency": 10.51
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "model": "Gemini 1.5 Pro (002)",
-            "company": "Google",
-            "accuracy": 66.1,
-            "cost_input": "$1.25",
-            "cost_output": "$5.00",
-            "latency": 43.73
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "model": "GPT 4o (2024-08-06)",
-            "company": "Openai",
-            "accuracy": 65.5,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 47.53
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "model": "Mistral Medium 3.1 (05/2025)",
-            "company": "Mistral",
-            "accuracy": 63.1,
-            "cost_input": "$0.40",
-            "cost_output": "$2.00",
-            "latency": 12.56
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "model": "Mistral Small 3.1 (03/2025)",
-            "company": "Mistral",
-            "accuracy": 60.6,
-            "cost_input": "$0.07",
-            "cost_output": "$0.30",
-            "latency": 13.4
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "model": "Llama 3.2 Vision (90B)",
-            "company": "Meta",
-            "accuracy": 58.8,
-            "cost_input": "$1.20",
-            "cost_output": "$1.20",
-            "latency": 56.34
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "model": "GPT 4o Mini",
-            "company": "Openai",
-            "accuracy": 58.2,
-            "cost_input": "$0.15",
-            "cost_output": "$0.60",
-            "latency": 45.02
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "model": "Gemini 1.5 Flash (002)",
-            "company": "Google",
-            "accuracy": 57.6,
-            "cost_input": "$0.07",
-            "cost_output": "$0.30",
-            "latency": 41.31
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "model": "GPT 4.1 Nano",
-            "company": "Openai",
-            "accuracy": 55.6,
-            "cost_input": "$0.10",
-            "cost_output": "$0.40",
-            "latency": 7.25
-        },
-        {
-            "benchmark": "mmmu-05-30-2025",
-            "model": "Llama 3.2 Vision (11B)",
-            "company": "Meta",
-            "accuracy": 50.3,
-            "cost_input": "$0.18",
-            "cost_output": "$0.18",
-            "latency": 38.07
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Grok 3 Beta",
-            "company": "xAI",
-            "accuracy": 88.1,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 3.91
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "DeepSeek V3 (03/24/2025)",
-            "company": "Deepseek",
-            "accuracy": 86.2,
-            "cost_input": "$1.20",
-            "cost_output": "$1.20",
-            "latency": 13.66
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Gemini 2.5 Pro Exp",
-            "company": "Google",
-            "accuracy": 86.1,
-            "cost_input": "$1.25",
-            "cost_output": "$10.00",
-            "latency": 8.05
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "GPT 4.1",
-            "company": "Openai",
-            "accuracy": 85.8,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 3.82
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Claude Sonnet 4 (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 85.2,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 8.03
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Claude 3.5 Sonnet Latest",
-            "company": "Anthropic",
-            "accuracy": 84.9,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 4.51
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Mistral Medium 3.1 (05/2025)",
-            "company": "Mistral",
-            "accuracy": 84.9,
-            "cost_input": "$0.40",
-            "cost_output": "$2.00",
-            "latency": 4.58
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Claude 3.7 Sonnet (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 84.8,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 13.13
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "DeepSeek V3",
-            "company": "Deepseek",
-            "accuracy": 84.5,
-            "cost_input": "$0.90",
-            "cost_output": "$0.90",
-            "latency": 8.72
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Gemini 2.0 Pro Exp",
-            "company": "Google",
-            "accuracy": 84.5,
-            "cost_input": "$1.25",
-            "cost_output": "$5.00",
-            "latency": 2.21
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "GPT 4.1 Mini",
-            "company": "Openai",
-            "accuracy": 84.3,
-            "cost_input": "$0.40",
-            "cost_output": "$1.60",
-            "latency": 2.55
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Claude Sonnet 4 (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 84.3,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 13.14
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Qwen 3 (235B)",
-            "company": "Alibaba",
-            "accuracy": 84.0,
-            "cost_input": "$0.22",
-            "cost_output": "$0.88",
-            "latency": 17.23
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Claude 3.5 Haiku Latest",
-            "company": "Anthropic",
-            "accuracy": 83.8,
-            "cost_input": "$1.00",
-            "cost_output": "$5.00",
-            "latency": 5.29
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Grok 3 Mini Fast High Reasoning",
-            "company": "xAI",
-            "accuracy": 83.6,
-            "cost_input": "$0.60",
-            "cost_output": "$4.00",
-            "latency": 6.27
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Grok 3 Mini Fast Low Reasoning",
-            "company": "xAI",
-            "accuracy": 83.4,
-            "cost_input": "$0.60",
-            "cost_output": "$4.00",
-            "latency": 4.98
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "GPT 4o (2024-08-06)",
-            "company": "Openai",
-            "accuracy": 83.3,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 4.27
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "GPT 4o (2024-11-20)",
-            "company": "Openai",
-            "accuracy": 82.9,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 3.14
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "o3",
-            "company": "Openai",
-            "accuracy": 82.8,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 10.04
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Gemini 2.5 Flash Preview (Thinking)",
-            "company": "Google",
-            "accuracy": 82.5,
-            "cost_input": "$0.15",
-            "cost_output": "$3.50",
-            "latency": 5.07
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "o1",
-            "company": "Openai",
-            "accuracy": 81.9,
-            "cost_input": "$15.00",
-            "cost_output": "$60.00",
-            "latency": 22.26
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Claude Opus 4 (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 81.5,
-            "cost_input": "$15.00",
-            "cost_output": "$75.00",
-            "latency": 11.93
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Gemini 2.5 Flash Preview (Nonthinking)",
-            "company": "Google",
-            "accuracy": 81.5,
-            "cost_input": "$0.15",
-            "cost_output": "$0.60",
-            "latency": 1.56
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Claude 3 Opus",
-            "company": "Anthropic",
-            "accuracy": 81.3,
-            "cost_input": "$15.00",
-            "cost_output": "$75.00",
-            "latency": 10.73
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "o4 Mini",
-            "company": "Openai",
-            "accuracy": 81.1,
-            "cost_input": "$1.10",
-            "cost_output": "$4.40",
-            "latency": 7.91
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "DeepSeek R1",
-            "company": "Deepseek",
-            "accuracy": 81.0,
-            "cost_input": "$8.00",
-            "cost_output": "$8.00",
-            "latency": 51.02
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Claude 3.7 Sonnet (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 80.7,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 5.78
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Llama 3.1 Instruct Turbo (8B)",
-            "company": "Meta",
-            "accuracy": 80.3,
-            "cost_input": "$0.18",
-            "cost_output": "$0.18",
-            "latency": 2.32
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Command A",
-            "company": "Cohere",
-            "accuracy": 79.7,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 5.5
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "o1 Preview",
-            "company": "Openai",
-            "accuracy": 78.6,
-            "cost_input": "$15.00",
-            "cost_output": "$60.00",
-            "latency": 3.96
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Grok 2",
-            "company": "xAI",
-            "accuracy": 78.6,
-            "cost_input": "$2.00",
-            "cost_output": "$10.00",
-            "latency": 3.96
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "o3 Mini",
-            "company": "Openai",
-            "accuracy": 78.5,
-            "cost_input": "$1.10",
-            "cost_output": "$4.40",
-            "latency": 15.35
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Claude 3 Sonnet",
-            "company": "Anthropic",
-            "accuracy": 78.5,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 6.13
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "GPT 4 Turbo",
-            "company": "Openai",
-            "accuracy": 77.9,
-            "cost_input": "$10.00",
-            "cost_output": "$30.00",
-            "latency": 8.55
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "o1 Mini",
-            "company": "Openai",
-            "accuracy": 77.8,
-            "cost_input": "$3.00",
-            "cost_output": "$12.00",
-            "latency": 6.36
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Llama 3.1 Instruct Turbo (70B)",
-            "company": "Meta",
-            "accuracy": 77.1,
-            "cost_input": "$0.88",
-            "cost_output": "$0.88",
-            "latency": 6.41
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Mixtral Instruct (8x22B)",
-            "company": "Mistral",
-            "accuracy": 76.8,
-            "cost_input": "$1.20",
-            "cost_output": "$1.20",
-            "latency": 6.45
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Mistral Small 3.1 (03/2025)",
-            "company": "Mistral",
-            "accuracy": 76.7,
-            "cost_input": "$0.07",
-            "cost_output": "$0.30",
-            "latency": 2.83
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Llama 3.3 Instruct Turbo (70B)",
-            "company": "Meta",
-            "accuracy": 76.6,
-            "cost_input": "$0.88",
-            "cost_output": "$0.88",
-            "latency": 32.1
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Llama 4 Maverick",
-            "company": "Meta",
-            "accuracy": 76.1,
-            "cost_input": "$0.27",
-            "cost_output": "$0.85",
-            "latency": 2.17
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "GPT 4.1 Nano",
-            "company": "Openai",
-            "accuracy": 75.5,
-            "cost_input": "$0.10",
-            "cost_output": "$0.40",
-            "latency": 1.43
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Jamba 1.6 Mini",
-            "company": "Ai21 Labs",
-            "accuracy": 75.3,
-            "cost_input": "$0.20",
-            "cost_output": "$0.40",
-            "latency": 2.27
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Mistral Large (11/2024)",
-            "company": "Mistral",
-            "accuracy": 75.1,
-            "cost_input": "$2.00",
-            "cost_output": "$6.00",
-            "latency": 4.78
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Llama 4 Scout",
-            "company": "Meta",
-            "accuracy": 74.4,
-            "cost_input": "$0.18",
-            "cost_output": "$0.59",
-            "latency": 3.07
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Gemini 2.0 Flash Thinking Exp",
-            "company": "Google",
-            "accuracy": 74.2,
-            "cost_input": "$0.10",
-            "cost_output": "$0.70",
-            "latency": 2.09
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Gemini 2.0 Flash (001)",
-            "company": "Google",
-            "accuracy": 73.7,
-            "cost_input": "$0.10",
-            "cost_output": "$0.40",
-            "latency": 1.14
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Mistral Small (02/2024)",
-            "company": "Mistral",
-            "accuracy": 73.5,
-            "cost_input": "$0.20",
-            "cost_output": "$0.60",
-            "latency": 3.97
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Command R",
-            "company": "Cohere",
-            "accuracy": 72.3,
-            "cost_input": "$0.15",
-            "cost_output": "$0.60",
-            "latency": 3.35
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Jamba 1.6 Large",
-            "company": "Ai21 Labs",
-            "accuracy": 71.8,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 8.7
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "GPT 4o Mini",
-            "company": "Openai",
-            "accuracy": 70.8,
-            "cost_input": "$0.15",
-            "cost_output": "$0.60",
-            "latency": 4.29
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Gemini 1.5 Pro (001)",
-            "company": "Google",
-            "accuracy": 67.6,
-            "cost_input": "$1.25",
-            "cost_output": "$5.00",
-            "latency": 4.53
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Gemini 1.5 Pro (002)",
-            "company": "Google",
-            "accuracy": 67.6,
-            "cost_input": "$1.25",
-            "cost_output": "$5.00",
-            "latency": 4.53
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Command R+",
-            "company": "Cohere",
-            "accuracy": 66.9,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 6.05
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Qwen 2.5 Instruct Turbo (72B)",
-            "company": "Alibaba",
-            "accuracy": 63.2,
-            "cost_input": "$1.20",
-            "cost_output": "$1.20",
-            "latency": 2.82
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Gemini 1.5 Flash (002)",
-            "company": "Google",
-            "accuracy": 62.8,
-            "cost_input": "$0.07",
-            "cost_output": "$0.30",
-            "latency": 2.05
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Jamba 1.5 Large",
-            "company": "Ai21 Labs",
-            "accuracy": 60.1,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 5.19
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "GPT 3.5",
-            "company": "Openai",
-            "accuracy": 58.4,
-            "cost_input": "$0.50",
-            "cost_output": "$1.50",
-            "latency": 2.13
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Qwen 2.5 Instruct Turbo (7B)",
-            "company": "Alibaba",
-            "accuracy": 58.4,
-            "cost_input": "$0.30",
-            "cost_output": "$0.30",
-            "latency": 1.43
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Gemini 1.0 Pro 002",
-            "company": "Google",
-            "accuracy": 58.1,
-            "cost_input": "$0.50",
-            "cost_output": "$1.50",
-            "latency": 5.79
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Claude 3.5 Sonnet",
-            "company": "Anthropic",
-            "accuracy": 53.9,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 1.88
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Jamba 1.5 Mini",
-            "company": "Ai21 Labs",
-            "accuracy": 53.0,
-            "cost_input": "$0.20",
-            "cost_output": "$0.40",
-            "latency": 1.24
-        },
-        {
-            "benchmark": "case_law-05-30-2025",
-            "model": "Mistral (7B)",
-            "company": "Mistral",
-            "accuracy": 40.0,
-            "cost_input": "$0.18",
-            "cost_output": "$0.18",
-            "latency": 4.33
-        },
-        {
             "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
             "model": "o3",
             "company": "Openai",
             "accuracy": 48.3,
@@ -3495,6 +463,7 @@
         },
         {
             "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
             "model": "Claude Sonnet 4 (Thinking)",
             "company": "Anthropic",
             "accuracy": 44.5,
@@ -3504,6 +473,7 @@
         },
         {
             "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
             "model": "Claude 3.7 Sonnet (Thinking)",
             "company": "Anthropic",
             "accuracy": 44.1,
@@ -3513,6 +483,7 @@
         },
         {
             "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
             "model": "Claude Sonnet 4 (Nonthinking)",
             "company": "Anthropic",
             "accuracy": 43.5,
@@ -3522,6 +493,7 @@
         },
         {
             "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
             "model": "Claude 3.7 Sonnet (Nonthinking)",
             "company": "Anthropic",
             "accuracy": 42.9,
@@ -3531,6 +503,7 @@
         },
         {
             "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
             "model": "o4 Mini",
             "company": "Openai",
             "accuracy": 36.5,
@@ -3540,6 +513,7 @@
         },
         {
             "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
             "model": "Grok 3 Mini Fast High Reasoning",
             "company": "xAI",
             "accuracy": 31.7,
@@ -3549,6 +523,7 @@
         },
         {
             "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
             "model": "Gemini 2.5 Pro Preview",
             "company": "Google",
             "accuracy": 29.4,
@@ -3558,6 +533,7 @@
         },
         {
             "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
             "model": "GPT 4.1",
             "company": "Openai",
             "accuracy": 24.6,
@@ -3567,6 +543,7 @@
         },
         {
             "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
             "model": "Grok 3 Beta",
             "company": "xAI",
             "accuracy": 24.1,
@@ -3576,6 +553,7 @@
         },
         {
             "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
             "model": "GPT 4.1 Mini",
             "company": "Openai",
             "accuracy": 20.8,
@@ -3585,6 +563,7 @@
         },
         {
             "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
             "model": "o1",
             "company": "Openai",
             "accuracy": 20.8,
@@ -3594,6 +573,7 @@
         },
         {
             "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
             "model": "GPT 4o (2024-08-06)",
             "company": "Openai",
             "accuracy": 19.3,
@@ -3603,6 +583,7 @@
         },
         {
             "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
             "model": "Grok 3 Mini Fast Low Reasoning",
             "company": "xAI",
             "accuracy": 17.1,
@@ -3612,6 +593,7 @@
         },
         {
             "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
             "model": "Claude 3.5 Haiku Latest",
             "company": "Anthropic",
             "accuracy": 14.3,
@@ -3621,6 +603,7 @@
         },
         {
             "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
             "model": "Gemini 2.0 Flash (001)",
             "company": "Google",
             "accuracy": 13.2,
@@ -3630,6 +613,7 @@
         },
         {
             "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
             "model": "o3 Mini",
             "company": "Openai",
             "accuracy": 12.7,
@@ -3639,6 +623,7 @@
         },
         {
             "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
             "model": "GPT 4o Mini",
             "company": "Openai",
             "accuracy": 10.8,
@@ -3648,6 +633,7 @@
         },
         {
             "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
             "model": "Mistral Small 3.1 (03/2025)",
             "company": "Mistral",
             "accuracy": 10.0,
@@ -3657,6 +643,7 @@
         },
         {
             "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
             "model": "Command A",
             "company": "Cohere",
             "accuracy": 4.3,
@@ -3666,6 +653,7 @@
         },
         {
             "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
             "model": "Llama 4 Maverick",
             "company": "Meta",
             "accuracy": 3.6,
@@ -3675,6 +663,7 @@
         },
         {
             "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
             "model": "Llama 3.3 Instruct Turbo (70B)",
             "company": "Meta",
             "accuracy": 3.4,
@@ -3684,6 +673,7 @@
         },
         {
             "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
             "model": "GPT 4.1 Nano",
             "company": "Openai",
             "accuracy": 2.5,
@@ -3693,6 +683,7 @@
         },
         {
             "benchmark": "finance_agent",
+            "benchmark_group": "Finance",
             "model": "Jamba 1.6 Mini",
             "company": "Ai21 Labs",
             "accuracy": 1.7,
@@ -3701,367 +692,798 @@
             "latency": 36.01
         },
         {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "o3",
-            "company": "Openai",
-            "accuracy": 83.6,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 65.78
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "Gemini 2.5 Pro Exp",
-            "company": "Google",
-            "accuracy": 80.3,
-            "cost_input": "$1.25",
-            "cost_output": "$10.00",
-            "latency": 41.1
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "Grok 3 Mini Fast High Reasoning",
-            "company": "xAI",
-            "accuracy": 79.0,
-            "cost_input": "$0.60",
-            "cost_output": "$4.00",
-            "latency": 40.62
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "Claude 3.7 Sonnet (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 75.3,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 155.02
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
             "model": "o3 Mini",
             "company": "Openai",
-            "accuracy": 75.0,
+            "accuracy": 86.5,
             "cost_input": "$1.10",
             "cost_output": "$4.40",
-            "latency": 99.98
+            "latency": 154.65
         },
         {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "o4 Mini",
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Gemini 2.5 Pro Exp",
+            "company": "Google",
+            "accuracy": 85.8,
+            "cost_input": "$1.25",
+            "cost_output": "$10.00",
+            "latency": 143.91
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "o3",
             "company": "Openai",
-            "accuracy": 74.5,
-            "cost_input": "$1.10",
-            "cost_output": "$4.40",
-            "latency": 30.0
+            "accuracy": 85.3,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 266.18
         },
         {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "Claude Sonnet 4 (Thinking)",
-            "company": "Anthropic",
-            "accuracy": 74.5,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 118.46
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "Grok 3 Beta",
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Grok 3 Mini Fast High Reasoning",
             "company": "xAI",
-            "accuracy": 73.7,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 29.91
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "o1",
-            "company": "Openai",
-            "accuracy": 73.0,
-            "cost_input": "$15.00",
-            "cost_output": "$60.00",
-            "latency": 40.18
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "Grok 3 Mini Fast Low Reasoning",
-            "company": "xAI",
-            "accuracy": 72.7,
+            "accuracy": 85.0,
             "cost_input": "$0.60",
             "cost_output": "$4.00",
-            "latency": 14.23
+            "latency": 102.25
         },
         {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "Claude Opus 4 (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 71.7,
-            "cost_input": "$15.00",
-            "cost_output": "$75.00",
-            "latency": 19.13
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "Claude Sonnet 4 (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 69.4,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 12.82
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "Llama 4 Maverick",
-            "company": "Meta",
-            "accuracy": 67.7,
-            "cost_input": "$0.27",
-            "cost_output": "$0.85",
-            "latency": 10.07
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "Claude 3.7 Sonnet (Nonthinking)",
-            "company": "Anthropic",
-            "accuracy": 67.4,
-            "cost_input": "$3.00",
-            "cost_output": "$15.00",
-            "latency": 9.22
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "GPT 4.1 Mini",
-            "company": "Openai",
-            "accuracy": 67.4,
-            "cost_input": "$0.40",
-            "cost_output": "$1.60",
-            "latency": 9.28
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
             "model": "Qwen 3 (235B)",
             "company": "Alibaba",
-            "accuracy": 66.4,
+            "accuracy": 84.0,
             "cost_input": "$0.22",
             "cost_output": "$0.88",
-            "latency": 306.22
+            "latency": 242.17
         },
         {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "Gemini 2.0 Flash (001)",
-            "company": "Google",
-            "accuracy": 65.2,
-            "cost_input": "$0.10",
-            "cost_output": "$0.40",
-            "latency": 5.8
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "GPT 4.1",
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "o4 Mini",
             "company": "Openai",
-            "accuracy": 64.6,
-            "cost_input": "$2.00",
-            "cost_output": "$8.00",
-            "latency": 23.14
+            "accuracy": 83.7,
+            "cost_input": "$1.10",
+            "cost_output": "$4.40",
+            "latency": 55.11
         },
         {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "DeepSeek V3 (03/24/2025)",
-            "company": "Deepseek",
-            "accuracy": 61.1,
-            "cost_input": "$1.20",
-            "cost_output": "$1.20",
-            "latency": 23.48
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "Claude 3.5 Sonnet Latest",
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Claude Sonnet 4 (Thinking)",
             "company": "Anthropic",
-            "accuracy": 59.1,
+            "accuracy": 76.3,
             "cost_input": "$3.00",
             "cost_output": "$15.00",
-            "latency": 7.24
+            "latency": 271.79
         },
         {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "Gemini 1.5 Pro (002)",
-            "company": "Google",
-            "accuracy": 58.3,
-            "cost_input": "$1.25",
-            "cost_output": "$5.00",
-            "latency": 7.71
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "DeepSeek V3",
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "DeepSeek R1",
             "company": "Deepseek",
-            "accuracy": 54.0,
-            "cost_input": "$0.90",
-            "cost_output": "$0.90",
-            "latency": 21.28
+            "accuracy": 74.0,
+            "cost_input": "$8.00",
+            "cost_output": "$8.00",
+            "latency": 153.91
         },
         {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "Gemini 2.5 Flash Preview (Nonthinking)",
-            "company": "Google",
-            "accuracy": 53.3,
-            "cost_input": "$0.15",
-            "cost_output": "$0.60",
-            "latency": 43.45
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "GPT 4o (2024-11-20)",
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "o1",
             "company": "Openai",
-            "accuracy": 53.0,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 14.92
+            "accuracy": 71.5,
+            "cost_input": "$15.00",
+            "cost_output": "$60.00",
+            "latency": 177.03
         },
         {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "Mistral Small (02/2024)",
-            "company": "Mistral",
-            "accuracy": 50.8,
-            "cost_input": "$0.20",
-            "cost_output": "$0.60",
-            "latency": 7.99
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "GPT 4o (2024-05-13)",
-            "company": "Openai",
-            "accuracy": 50.3,
-            "cost_input": "$5.00",
-            "cost_output": "$15.00",
-            "latency": 10.08
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "Llama 3.3 Instruct Turbo (70B)",
-            "company": "Meta",
-            "accuracy": 50.0,
-            "cost_input": "$0.88",
-            "cost_output": "$0.88",
-            "latency": 7.34
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "Grok 2",
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Grok 3 Mini Fast Low Reasoning",
             "company": "xAI",
-            "accuracy": 50.0,
-            "cost_input": "$2.00",
-            "cost_output": "$10.00",
-            "latency": 20.18
+            "accuracy": 70.6,
+            "cost_input": "$0.60",
+            "cost_output": "$4.00",
+            "latency": 31.4
         },
         {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "Gemini 1.5 Flash (002)",
-            "company": "Google",
-            "accuracy": 46.0,
-            "cost_input": "$0.07",
-            "cost_output": "$0.30",
-            "latency": 3.39
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Grok 3 Beta",
+            "company": "xAI",
+            "accuracy": 58.7,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 63.99
         },
         {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "Mistral Large (11/2024)",
-            "company": "Mistral",
-            "accuracy": 45.2,
-            "cost_input": "$2.00",
-            "cost_output": "$6.00",
-            "latency": 15.8
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "DeepSeek V3 (03/24/2025)",
+            "company": "Deepseek",
+            "accuracy": 52.2,
+            "cost_input": "$1.20",
+            "cost_output": "$1.20",
+            "latency": 50.57
         },
         {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "Llama 4 Scout",
-            "company": "Meta",
-            "accuracy": 44.4,
-            "cost_input": "$0.18",
-            "cost_output": "$0.59",
-            "latency": 12.09
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "GPT 4o Mini",
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "GPT 4.1 Mini",
             "company": "Openai",
-            "accuracy": 44.2,
-            "cost_input": "$0.15",
-            "cost_output": "$0.60",
-            "latency": 15.32
+            "accuracy": 49.4,
+            "cost_input": "$0.40",
+            "cost_output": "$1.60",
+            "latency": 33.14
         },
         {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "Mistral Small 3.1 (03/2025)",
-            "company": "Mistral",
-            "accuracy": 41.4,
-            "cost_input": "$0.07",
-            "cost_output": "$0.30",
-            "latency": 8.82
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "GPT 4.1 Nano",
-            "company": "Openai",
-            "accuracy": 39.9,
-            "cost_input": "$0.10",
-            "cost_output": "$0.40",
-            "latency": 4.19
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "Claude 3.5 Haiku Latest",
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Claude 3.7 Sonnet (Thinking)",
             "company": "Anthropic",
-            "accuracy": 37.9,
-            "cost_input": "$1.00",
-            "cost_output": "$5.00",
-            "latency": 6.56
+            "accuracy": 44.6,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 303.71
         },
         {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "GPT 3.5",
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Mistral Medium 3.1 (05/2025)",
+            "company": "Mistral",
+            "accuracy": 42.3,
+            "cost_input": "$0.40",
+            "cost_output": "$2.00",
+            "latency": 65.95
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Claude Opus 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 41.3,
+            "cost_input": "$15.00",
+            "cost_output": "$75.00",
+            "latency": 37.03
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "GPT 4.1",
             "company": "Openai",
-            "accuracy": 29.3,
-            "cost_input": "$0.50",
-            "cost_output": "$1.50",
-            "latency": 2.63
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "Command A",
-            "company": "Cohere",
-            "accuracy": 29.3,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 11.49
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "Command R+",
-            "company": "Cohere",
-            "accuracy": 29.0,
-            "cost_input": "$2.50",
-            "cost_output": "$10.00",
-            "latency": 8.19
-        },
-        {
-            "benchmark": "gpqa-05-30-2025",
-            "model": "Jamba 1.6 Large",
-            "company": "Ai21 Labs",
-            "accuracy": 24.2,
+            "accuracy": 39.8,
             "cost_input": "$2.00",
             "cost_output": "$8.00",
-            "latency": 15.47
+            "latency": 161.08
         },
         {
-            "benchmark": "gpqa-05-30-2025",
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Claude Sonnet 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 38.5,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 23.4
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Gemini 2.0 Flash (001)",
+            "company": "Google",
+            "accuracy": 29.8,
+            "cost_input": "$0.10",
+            "cost_output": "$0.40",
+            "latency": 11.21
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "DeepSeek V3",
+            "company": "Deepseek",
+            "accuracy": 27.5,
+            "cost_input": "$0.90",
+            "cost_output": "$0.90",
+            "latency": 58.8
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "GPT 4.1 Nano",
+            "company": "Openai",
+            "accuracy": 27.3,
+            "cost_input": "$0.10",
+            "cost_output": "$0.40",
+            "latency": 11.91
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Llama 4 Maverick",
+            "company": "Meta",
+            "accuracy": 25.2,
+            "cost_input": "$0.27",
+            "cost_output": "$0.85",
+            "latency": 15.5
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Claude 3.7 Sonnet (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 22.3,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 18.93
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Llama 4 Scout",
+            "company": "Meta",
+            "accuracy": 19.0,
+            "cost_input": "$0.18",
+            "cost_output": "$0.59",
+            "latency": 21.69
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Gemini 1.5 Pro (002)",
+            "company": "Google",
+            "accuracy": 18.7,
+            "cost_input": "$1.25",
+            "cost_output": "$5.00",
+            "latency": 10.64
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Gemini 1.5 Flash (002)",
+            "company": "Google",
+            "accuracy": 17.3,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 5.7
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Llama 3.3 Instruct Turbo (70B)",
+            "company": "Meta",
+            "accuracy": 16.0,
+            "cost_input": "$0.88",
+            "cost_output": "$0.88",
+            "latency": 11.24
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Grok 2",
+            "company": "xAI",
+            "accuracy": 15.2,
+            "cost_input": "$2.00",
+            "cost_output": "$10.00",
+            "latency": 57.88
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "GPT 4o (2024-08-06)",
+            "company": "Openai",
+            "accuracy": 14.0,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 68.37
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Command A",
+            "company": "Cohere",
+            "accuracy": 13.3,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 23.35
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "GPT 4o (2024-11-20)",
+            "company": "Openai",
+            "accuracy": 11.9,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 15.78
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "GPT 4o Mini",
+            "company": "Openai",
+            "accuracy": 11.5,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": 28.77
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Claude 3.5 Sonnet Latest",
+            "company": "Anthropic",
+            "accuracy": 10.0,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 9.19
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Mistral Large (11/2024)",
+            "company": "Mistral",
+            "accuracy": 9.2,
+            "cost_input": "$2.00",
+            "cost_output": "$6.00",
+            "latency": 19.68
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Mistral Small (02/2024)",
+            "company": "Mistral",
+            "accuracy": 5.6,
+            "cost_input": "$0.20",
+            "cost_output": "$0.60",
+            "latency": 13.23
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Mistral Small 3.1 (03/2025)",
+            "company": "Mistral",
+            "accuracy": 3.5,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 11.68
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Claude 3.5 Haiku Latest",
+            "company": "Anthropic",
+            "accuracy": 3.3,
+            "cost_input": "$1.00",
+            "cost_output": "$5.00",
+            "latency": 9.05
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
+            "model": "Jamba 1.6 Large",
+            "company": "Ai21 Labs",
+            "accuracy": 0.4,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 18.86
+        },
+        {
+            "benchmark": "aime-2025-05-30",
+            "benchmark_group": "Math",
             "model": "Jamba 1.6 Mini",
             "company": "Ai21 Labs",
-            "accuracy": 20.5,
+            "accuracy": 0.4,
             "cost_input": "$0.20",
             "cost_output": "$0.40",
-            "latency": 4.95
+            "latency": 6.62
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Claude Opus 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 86.1,
+            "cost_input": "$15.00",
+            "cost_output": "$75.00",
+            "latency": 10.41
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "o3",
+            "company": "Openai",
+            "accuracy": 85.6,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 16.74
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Gemini 2.5 Pro Exp",
+            "company": "Google",
+            "accuracy": 84.1,
+            "cost_input": "$1.25",
+            "cost_output": "$10.00",
+            "latency": 18.46
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Claude Sonnet 4 (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 83.8,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 47.09
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "o1",
+            "company": "Openai",
+            "accuracy": 83.5,
+            "cost_input": "$15.00",
+            "cost_output": "$60.00",
+            "latency": 26.87
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Claude 3.7 Sonnet (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 82.7,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 31.74
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Grok 3 Mini Fast High Reasoning",
+            "company": "xAI",
+            "accuracy": 81.4,
+            "cost_input": "$0.60",
+            "cost_output": "$4.00",
+            "latency": 16.89
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Claude 3.7 Sonnet (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 80.7,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 6.3
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "o4 Mini",
+            "company": "Openai",
+            "accuracy": 80.6,
+            "cost_input": "$1.10",
+            "cost_output": "$4.40",
+            "latency": 10.44
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "GPT 4.1",
+            "company": "Openai",
+            "accuracy": 80.5,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 8.18
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Qwen 3 (235B)",
+            "company": "Alibaba",
+            "accuracy": 80.4,
+            "cost_input": "$0.22",
+            "cost_output": "$0.88",
+            "latency": 52.35
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Grok 3 Mini Fast Low Reasoning",
+            "company": "xAI",
+            "accuracy": 80.0,
+            "cost_input": "$0.60",
+            "cost_output": "$4.00",
+            "latency": 7.43
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Grok 3 Beta",
+            "company": "xAI",
+            "accuracy": 79.9,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 12.1
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Claude Sonnet 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 79.4,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 9.71
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Llama 4 Maverick",
+            "company": "Meta",
+            "accuracy": 79.4,
+            "cost_input": "$0.27",
+            "cost_output": "$0.85",
+            "latency": 6.8
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "DeepSeek V3 (03/24/2025)",
+            "company": "Deepseek",
+            "accuracy": 78.9,
+            "cost_input": "$1.20",
+            "cost_output": "$1.20",
+            "latency": 25.05
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "o3 Mini",
+            "company": "Openai",
+            "accuracy": 78.7,
+            "cost_input": "$1.10",
+            "cost_output": "$4.40",
+            "latency": 22.38
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Claude 3.5 Sonnet Latest",
+            "company": "Anthropic",
+            "accuracy": 78.4,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 6.29
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Gemini 2.0 Flash (001)",
+            "company": "Google",
+            "accuracy": 77.4,
+            "cost_input": "$0.10",
+            "cost_output": "$0.40",
+            "latency": 4.32
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "GPT 4.1 Mini",
+            "company": "Openai",
+            "accuracy": 77.2,
+            "cost_input": "$0.40",
+            "cost_output": "$1.60",
+            "latency": 3.83
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Grok 2",
+            "company": "xAI",
+            "accuracy": 75.5,
+            "cost_input": "$2.00",
+            "cost_output": "$10.00",
+            "latency": 8.75
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Gemini 1.5 Pro (002)",
+            "company": "Google",
+            "accuracy": 75.3,
+            "cost_input": "$1.25",
+            "cost_output": "$5.00",
+            "latency": 3.34
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Mistral Medium 3.1 (05/2025)",
+            "company": "Mistral",
+            "accuracy": 74.4,
+            "cost_input": "$0.40",
+            "cost_output": "$2.00",
+            "latency": 8.83
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "GPT 4o (2024-08-06)",
+            "company": "Openai",
+            "accuracy": 74.1,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 9.0
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "DeepSeek V3",
+            "company": "Deepseek",
+            "accuracy": 73.8,
+            "cost_input": "$0.90",
+            "cost_output": "$0.90",
+            "latency": 11.36
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "DeepSeek R1",
+            "company": "Deepseek",
+            "accuracy": 71.1,
+            "cost_input": "$8.00",
+            "cost_output": "$8.00",
+            "latency": 27.28
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Llama 3.3 Instruct Turbo (70B)",
+            "company": "Meta",
+            "accuracy": 69.9,
+            "cost_input": "$0.88",
+            "cost_output": "$0.88",
+            "latency": 4.18
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Mistral Large (11/2024)",
+            "company": "Mistral",
+            "accuracy": 69.7,
+            "cost_input": "$2.00",
+            "cost_output": "$6.00",
+            "latency": 7.19
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Llama 4 Scout",
+            "company": "Meta",
+            "accuracy": 69.6,
+            "cost_input": "$0.18",
+            "cost_output": "$0.59",
+            "latency": 5.34
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "GPT 4o (2024-11-20)",
+            "company": "Openai",
+            "accuracy": 69.1,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 9.14
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Mistral Small 3.1 (03/2025)",
+            "company": "Mistral",
+            "accuracy": 66.0,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 3.6
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Gemini 1.5 Flash (002)",
+            "company": "Google",
+            "accuracy": 65.5,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 1.68
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Command A",
+            "company": "Cohere",
+            "accuracy": 65.2,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 9.85
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Mistral Small (02/2024)",
+            "company": "Mistral",
+            "accuracy": 64.4,
+            "cost_input": "$0.20",
+            "cost_output": "$0.60",
+            "latency": 4.66
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Claude 3.5 Haiku Latest",
+            "company": "Anthropic",
+            "accuracy": 64.1,
+            "cost_input": "$1.00",
+            "cost_output": "$5.00",
+            "latency": 5.79
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "GPT 4o Mini",
+            "company": "Openai",
+            "accuracy": 62.7,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": 5.09
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "GPT 4.1 Nano",
+            "company": "Openai",
+            "accuracy": 62.3,
+            "cost_input": "$0.10",
+            "cost_output": "$0.40",
+            "latency": 2.4
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Jamba 1.6 Large",
+            "company": "Ai21 Labs",
+            "accuracy": 49.3,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 9.48
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Command R+",
+            "company": "Cohere",
+            "accuracy": 43.9,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 4.42
+        },
+        {
+            "benchmark": "mmlu_pro-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Jamba 1.6 Mini",
+            "company": "Ai21 Labs",
+            "accuracy": 30.2,
+            "cost_input": "$0.20",
+            "cost_output": "$0.40",
+            "latency": 2.43
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Gemini 2.5 Pro Exp",
             "company": "Google",
             "accuracy": 83.6,
@@ -4071,6 +1493,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Gemini 2.5 Flash Preview (Nonthinking)",
             "company": "Google",
             "accuracy": 82.8,
@@ -4080,6 +1503,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "o3",
             "company": "Openai",
             "accuracy": 82.5,
@@ -4089,6 +1513,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Grok 3 Mini Fast High Reasoning",
             "company": "xAI",
             "accuracy": 82.0,
@@ -4098,6 +1523,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Grok 3 Beta",
             "company": "xAI",
             "accuracy": 82.0,
@@ -4107,6 +1533,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "GPT 4.1",
             "company": "Openai",
             "accuracy": 81.9,
@@ -4116,6 +1543,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Gemini 2.5 Flash Preview (Thinking)",
             "company": "Google",
             "accuracy": 81.8,
@@ -4125,6 +1553,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "o1 Preview",
             "company": "Openai",
             "accuracy": 81.7,
@@ -4134,6 +1563,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Grok 3 Mini Fast Low Reasoning",
             "company": "xAI",
             "accuracy": 81.6,
@@ -4143,6 +1573,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Claude Opus 4 (Nonthinking)",
             "company": "Anthropic",
             "accuracy": 81.6,
@@ -4152,6 +1583,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Claude Sonnet 4 (Nonthinking)",
             "company": "Anthropic",
             "accuracy": 81.5,
@@ -4161,6 +1593,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Claude Sonnet 4 (Thinking)",
             "company": "Anthropic",
             "accuracy": 81.3,
@@ -4170,6 +1603,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "DeepSeek V3",
             "company": "Deepseek",
             "accuracy": 80.1,
@@ -4179,6 +1613,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "DeepSeek V3 (03/24/2025)",
             "company": "Deepseek",
             "accuracy": 79.9,
@@ -4188,6 +1623,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "GPT 4o (2024-11-20)",
             "company": "Openai",
             "accuracy": 79.8,
@@ -4197,6 +1633,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Gemini 2.0 Flash (001)",
             "company": "Google",
             "accuracy": 79.7,
@@ -4206,6 +1643,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Claude 3.7 Sonnet (Thinking)",
             "company": "Anthropic",
             "accuracy": 79.3,
@@ -4215,6 +1653,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Qwen 2.5 Instruct Turbo (72B)",
             "company": "Alibaba",
             "accuracy": 79.2,
@@ -4224,6 +1663,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Qwen 3 (235B)",
             "company": "Alibaba",
             "accuracy": 79.2,
@@ -4233,6 +1673,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "o4 Mini",
             "company": "Openai",
             "accuracy": 79.0,
@@ -4242,6 +1683,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Llama 3.1 Instruct Turbo (405B)",
             "company": "Meta",
             "accuracy": 79.0,
@@ -4251,6 +1693,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "GPT 4o (2024-08-06)",
             "company": "Openai",
             "accuracy": 79.0,
@@ -4260,6 +1703,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Claude 3.5 Sonnet Latest",
             "company": "Anthropic",
             "accuracy": 78.8,
@@ -4269,6 +1713,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Command A",
             "company": "Cohere",
             "accuracy": 78.7,
@@ -4278,6 +1723,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "o1 Mini",
             "company": "Openai",
             "accuracy": 78.7,
@@ -4287,6 +1733,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Llama 3.1 Instruct Turbo (70B)",
             "company": "Meta",
             "accuracy": 78.2,
@@ -4296,6 +1743,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Claude 3.7 Sonnet (Nonthinking)",
             "company": "Anthropic",
             "accuracy": 78.1,
@@ -4305,6 +1753,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Llama 3.3 Instruct Turbo (70B)",
             "company": "Meta",
             "accuracy": 78.0,
@@ -4314,6 +1763,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "GPT 4 Turbo",
             "company": "Openai",
             "accuracy": 78.0,
@@ -4323,6 +1773,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Claude 3.5 Sonnet",
             "company": "Anthropic",
             "accuracy": 77.6,
@@ -4332,6 +1783,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "o1",
             "company": "Openai",
             "accuracy": 77.6,
@@ -4341,6 +1793,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Claude 3 Opus",
             "company": "Anthropic",
             "accuracy": 77.5,
@@ -4350,6 +1803,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Llama 4 Maverick",
             "company": "Meta",
             "accuracy": 77.2,
@@ -4359,6 +1813,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "GPT 4.1 Mini",
             "company": "Openai",
             "accuracy": 76.8,
@@ -4368,6 +1823,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "GPT 4o Mini",
             "company": "Openai",
             "accuracy": 76.2,
@@ -4377,6 +1833,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Jamba 1.5 Large",
             "company": "Ai21 Labs",
             "accuracy": 74.8,
@@ -4386,6 +1843,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Gemini 1.5 Pro (001)",
             "company": "Google",
             "accuracy": 74.4,
@@ -4395,6 +1853,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Jamba 1.6 Large",
             "company": "Ai21 Labs",
             "accuracy": 74.1,
@@ -4404,6 +1863,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Gemini 1.0 Pro 002",
             "company": "Google",
             "accuracy": 73.4,
@@ -4413,6 +1873,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Claude 3.5 Haiku Latest",
             "company": "Anthropic",
             "accuracy": 73.0,
@@ -4422,6 +1883,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Qwen 2.5 Instruct Turbo (7B)",
             "company": "Alibaba",
             "accuracy": 72.4,
@@ -4431,6 +1893,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Claude 3 Sonnet",
             "company": "Anthropic",
             "accuracy": 72.3,
@@ -4440,6 +1903,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Llama 4 Scout",
             "company": "Meta",
             "accuracy": 71.8,
@@ -4449,6 +1913,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Gemini 1.5 Pro (002)",
             "company": "Google",
             "accuracy": 71.6,
@@ -4458,6 +1923,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Mistral Small 3.1 (03/2025)",
             "company": "Mistral",
             "accuracy": 70.9,
@@ -4467,6 +1933,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "o3 Mini",
             "company": "Openai",
             "accuracy": 70.9,
@@ -4476,6 +1943,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Command R+",
             "company": "Cohere",
             "accuracy": 70.5,
@@ -4485,6 +1953,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Gemma 2 (9B)",
             "company": "Google",
             "accuracy": 70.0,
@@ -4494,6 +1963,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "DeepSeek R1",
             "company": "Deepseek",
             "accuracy": 69.9,
@@ -4503,6 +1973,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Jamba 1.6 Mini",
             "company": "Ai21 Labs",
             "accuracy": 69.7,
@@ -4512,6 +1983,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Command",
             "company": "Cohere",
             "accuracy": 68.8,
@@ -4521,6 +1993,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Jamba 1.5 Mini",
             "company": "Ai21 Labs",
             "accuracy": 68.1,
@@ -4530,6 +2003,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Gemma 2 (27B)",
             "company": "Google",
             "accuracy": 65.5,
@@ -4539,6 +2013,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "GPT 3.5",
             "company": "Openai",
             "accuracy": 64.8,
@@ -4548,6 +2023,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Gemini 1.5 Flash (002)",
             "company": "Google",
             "accuracy": 62.0,
@@ -4557,6 +2033,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Mistral Medium 3.1 (05/2025)",
             "company": "Mistral",
             "accuracy": 61.3,
@@ -4566,6 +2043,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Llama 2 (70B)",
             "company": "Meta",
             "accuracy": 59.4,
@@ -4575,6 +2053,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "GPT 4.1 Nano",
             "company": "Openai",
             "accuracy": 58.3,
@@ -4584,6 +2063,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Mixtral (8x7B)",
             "company": "Mistral",
             "accuracy": 53.3,
@@ -4593,6 +2073,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Llama 3.1 Instruct Turbo (8B)",
             "company": "Meta",
             "accuracy": 52.5,
@@ -4602,6 +2083,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Llama 2 (13B)",
             "company": "Meta",
             "accuracy": 51.6,
@@ -4611,6 +2093,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Mistral (7B)",
             "company": "Mistral",
             "accuracy": 51.0,
@@ -4620,6 +2103,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Falcon (40B)",
             "company": "Technology Innovation Institute",
             "accuracy": 50.9,
@@ -4629,6 +2113,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Llama 2 (7B)",
             "company": "Meta",
             "accuracy": 49.3,
@@ -4638,6 +2123,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Falcon (7B)",
             "company": "Technology Innovation Institute",
             "accuracy": 47.1,
@@ -4647,6 +2133,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "DBRX Instruct",
             "company": "Databricks",
             "accuracy": 35.6,
@@ -4656,6 +2143,7 @@
         },
         {
             "benchmark": "legal_bench-05-30-2025",
+            "benchmark_group": "Legal",
             "model": "Command R",
             "company": "Cohere",
             "accuracy": 35.0,
@@ -4664,7 +2152,3868 @@
             "latency": 0.19
         },
         {
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Gemini 2.5 Pro Exp",
+            "company": "Google",
+            "accuracy": 81.5,
+            "cost_input": "$1.25",
+            "cost_output": "$10.00",
+            "latency": 24.15
+        },
+        {
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "o3",
+            "company": "Openai",
+            "accuracy": 80.1,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 39.27
+        },
+        {
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "o4 Mini",
+            "company": "Openai",
+            "accuracy": 79.7,
+            "cost_input": "$1.10",
+            "cost_output": "$4.40",
+            "latency": 19.72
+        },
+        {
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "o1",
+            "company": "Openai",
+            "accuracy": 77.7,
+            "cost_input": "$15.00",
+            "cost_output": "$60.00",
+            "latency": 26.41
+        },
+        {
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Claude 3.7 Sonnet (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 76.0,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 69.58
+        },
+        {
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Claude Sonnet 4 (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 75.1,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 48.85
+        },
+        {
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Claude Opus 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 73.4,
+            "cost_input": "$15.00",
+            "cost_output": "$75.00",
+            "latency": 14.02
+        },
+        {
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Llama 4 Maverick",
+            "company": "Meta",
+            "accuracy": 72.6,
+            "cost_input": "$0.27",
+            "cost_output": "$0.85",
+            "latency": 7.91
+        },
+        {
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Claude Sonnet 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 72.6,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 10.82
+        },
+        {
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Gemini 2.0 Flash (001)",
+            "company": "Google",
+            "accuracy": 71.9,
+            "cost_input": "$0.10",
+            "cost_output": "$0.40",
+            "latency": 45.22
+        },
+        {
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Claude 3.7 Sonnet (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 71.6,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 8.32
+        },
+        {
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "GPT 4.1 Mini",
+            "company": "Openai",
+            "accuracy": 71.1,
+            "cost_input": "$0.40",
+            "cost_output": "$1.60",
+            "latency": 8.23
+        },
+        {
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Claude 3.5 Sonnet Latest",
+            "company": "Anthropic",
+            "accuracy": 68.9,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 46.01
+        },
+        {
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "GPT 4.1",
+            "company": "Openai",
+            "accuracy": 68.9,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 12.0
+        },
+        {
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "GPT 4o (2024-11-20)",
+            "company": "Openai",
+            "accuracy": 68.1,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 45.87
+        },
+        {
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Grok 2 Vision",
+            "company": "xAI",
+            "accuracy": 66.5,
+            "cost_input": "$2.00",
+            "cost_output": "$10.00",
+            "latency": 18.36
+        },
+        {
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Llama 4 Scout",
+            "company": "Meta",
+            "accuracy": 66.5,
+            "cost_input": "$0.18",
+            "cost_output": "$0.59",
+            "latency": 10.51
+        },
+        {
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Gemini 1.5 Pro (002)",
+            "company": "Google",
+            "accuracy": 66.1,
+            "cost_input": "$1.25",
+            "cost_output": "$5.00",
+            "latency": 43.73
+        },
+        {
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "GPT 4o (2024-08-06)",
+            "company": "Openai",
+            "accuracy": 65.5,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 47.53
+        },
+        {
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Mistral Medium 3.1 (05/2025)",
+            "company": "Mistral",
+            "accuracy": 63.1,
+            "cost_input": "$0.40",
+            "cost_output": "$2.00",
+            "latency": 12.56
+        },
+        {
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Mistral Small 3.1 (03/2025)",
+            "company": "Mistral",
+            "accuracy": 60.6,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 13.4
+        },
+        {
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Llama 3.2 Vision (90B)",
+            "company": "Meta",
+            "accuracy": 58.8,
+            "cost_input": "$1.20",
+            "cost_output": "$1.20",
+            "latency": 56.34
+        },
+        {
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "GPT 4o Mini",
+            "company": "Openai",
+            "accuracy": 58.2,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": 45.02
+        },
+        {
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Gemini 1.5 Flash (002)",
+            "company": "Google",
+            "accuracy": 57.6,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 41.31
+        },
+        {
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "GPT 4.1 Nano",
+            "company": "Openai",
+            "accuracy": 55.6,
+            "cost_input": "$0.10",
+            "cost_output": "$0.40",
+            "latency": 7.25
+        },
+        {
+            "benchmark": "mmmu-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Llama 3.2 Vision (11B)",
+            "company": "Meta",
+            "accuracy": 50.3,
+            "cost_input": "$0.18",
+            "cost_output": "$0.18",
+            "latency": 38.07
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 3.1 Instruct Turbo (405B)",
+            "company": "Meta",
+            "accuracy": 75.2,
+            "cost_input": "$3.50",
+            "cost_output": "$3.50",
+            "latency": 2.19
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude 3 Opus",
+            "company": "Anthropic",
+            "accuracy": 74.0,
+            "cost_input": "$15.00",
+            "cost_output": "$75.00",
+            "latency": 5.97
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Qwen 2.5 Instruct Turbo (72B)",
+            "company": "Alibaba",
+            "accuracy": 73.6,
+            "cost_input": "$1.20",
+            "cost_output": "$1.20",
+            "latency": 1.01
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude 3.7 Sonnet (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 73.0,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 8.87
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "o1 Mini",
+            "company": "Openai",
+            "accuracy": 72.8,
+            "cost_input": "$3.00",
+            "cost_output": "$12.00",
+            "latency": 4.01
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "o1",
+            "company": "Openai",
+            "accuracy": 72.7,
+            "cost_input": "$15.00",
+            "cost_output": "$60.00",
+            "latency": 11.26
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "GPT 4o Mini",
+            "company": "Openai",
+            "accuracy": 72.4,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": 1.92
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude Sonnet 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 72.4,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 2.91
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "GPT 4 Turbo",
+            "company": "Openai",
+            "accuracy": 71.8,
+            "cost_input": "$10.00",
+            "cost_output": "$30.00",
+            "latency": 3.26
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "GPT 4.1 Mini",
+            "company": "Openai",
+            "accuracy": 71.5,
+            "cost_input": "$0.40",
+            "cost_output": "$1.60",
+            "latency": 1.03
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Grok 3 Mini Fast Low Reasoning",
+            "company": "xAI",
+            "accuracy": 70.8,
+            "cost_input": "$0.60",
+            "cost_output": "$4.00",
+            "latency": 4.92
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemini 1.5 Flash (002)",
+            "company": "Google",
+            "accuracy": 70.4,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 0.8
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "o3 Mini",
+            "company": "Openai",
+            "accuracy": 69.3,
+            "cost_input": "$1.10",
+            "cost_output": "$4.40",
+            "latency": 46.24
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "o1 Preview",
+            "company": "Openai",
+            "accuracy": 69.0,
+            "cost_input": "$15.00",
+            "cost_output": "$60.00",
+            "latency": 12.83
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "o4 Mini",
+            "company": "Openai",
+            "accuracy": 68.9,
+            "cost_input": "$1.10",
+            "cost_output": "$4.40",
+            "latency": 4.53
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude Opus 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 68.8,
+            "cost_input": "$15.00",
+            "cost_output": "$75.00",
+            "latency": 4.37
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude 3.5 Sonnet Latest",
+            "company": "Anthropic",
+            "accuracy": 68.7,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 2.28
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude 3.5 Haiku Latest",
+            "company": "Anthropic",
+            "accuracy": 68.7,
+            "cost_input": "$1.00",
+            "cost_output": "$5.00",
+            "latency": 2.88
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 3.1 Instruct Turbo (70B)",
+            "company": "Meta",
+            "accuracy": 68.6,
+            "cost_input": "$0.88",
+            "cost_output": "$0.88",
+            "latency": 4.74
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "GPT 4.1",
+            "company": "Openai",
+            "accuracy": 68.4,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 1.11
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "DeepSeek V3",
+            "company": "Deepseek",
+            "accuracy": 68.4,
+            "cost_input": "$0.90",
+            "cost_output": "$0.90",
+            "latency": 2.15
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Command R+",
+            "company": "Cohere",
+            "accuracy": 68.2,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 1.17
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude 3.5 Sonnet",
+            "company": "Anthropic",
+            "accuracy": 68.2,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 1.61
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude 3.7 Sonnet (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 68.1,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 2.29
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemini 1.5 Pro (001)",
+            "company": "Google",
+            "accuracy": 68.0,
+            "cost_input": "$1.25",
+            "cost_output": "$5.00",
+            "latency": 4.11
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemini 1.5 Pro (002)",
+            "company": "Google",
+            "accuracy": 68.0,
+            "cost_input": "$1.25",
+            "cost_output": "$5.00",
+            "latency": 4.11
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "GPT 4o (2024-11-20)",
+            "company": "Openai",
+            "accuracy": 68.0,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 1.03
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Command A",
+            "company": "Cohere",
+            "accuracy": 67.7,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 1.44
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude 3 Sonnet",
+            "company": "Anthropic",
+            "accuracy": 67.6,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 3.03
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Mistral Large (11/2024)",
+            "company": "Mistral",
+            "accuracy": 67.0,
+            "cost_input": "$2.00",
+            "cost_output": "$6.00",
+            "latency": 2.16
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemini 2.0 Flash (001)",
+            "company": "Google",
+            "accuracy": 66.8,
+            "cost_input": "$0.10",
+            "cost_output": "$0.40",
+            "latency": 0.7
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 3 (70B)",
+            "company": "Meta",
+            "accuracy": 66.8,
+            "cost_input": "$0.90",
+            "cost_output": "$0.90",
+            "latency": 2.92
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemini 1.0 Pro 002",
+            "company": "Google",
+            "accuracy": 66.7,
+            "cost_input": "$0.50",
+            "cost_output": "$1.50",
+            "latency": 0.89
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Command R",
+            "company": "Cohere",
+            "accuracy": 66.7,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": 0.56
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Mistral Medium 3.1 (05/2025)",
+            "company": "Mistral",
+            "accuracy": 66.2,
+            "cost_input": "$0.40",
+            "cost_output": "$2.00",
+            "latency": 1.99
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Jamba 1.6 Mini",
+            "company": "Ai21 Labs",
+            "accuracy": 66.1,
+            "cost_input": "$0.20",
+            "cost_output": "$0.40",
+            "latency": 0.61
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "o3",
+            "company": "Openai",
+            "accuracy": 66.0,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 6.02
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 3.3 Instruct Turbo (70B)",
+            "company": "Meta",
+            "accuracy": 66.0,
+            "cost_input": "$0.88",
+            "cost_output": "$0.88",
+            "latency": 1.01
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude Sonnet 4 (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 66.0,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 10.83
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Mistral Small 3.1 (03/2025)",
+            "company": "Mistral",
+            "accuracy": 65.9,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 1.45
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Mixtral (8x7B)",
+            "company": "Mistral",
+            "accuracy": 64.9,
+            "cost_input": "$0.60",
+            "cost_output": "$0.60",
+            "latency": 1.11
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemini 2.5 Pro Exp",
+            "company": "Google",
+            "accuracy": 64.7,
+            "cost_input": "$1.25",
+            "cost_output": "$10.00",
+            "latency": 8.38
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "DeepSeek V3 (03/24/2025)",
+            "company": "Deepseek",
+            "accuracy": 64.7,
+            "cost_input": "$1.20",
+            "cost_output": "$1.20",
+            "latency": 4.22
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Mistral Small (02/2024)",
+            "company": "Mistral",
+            "accuracy": 64.1,
+            "cost_input": "$0.20",
+            "cost_output": "$0.60",
+            "latency": 1.57
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Qwen 3 (235B)",
+            "company": "Alibaba",
+            "accuracy": 63.6,
+            "cost_input": "$0.22",
+            "cost_output": "$0.88",
+            "latency": 17.6
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Grok 3 Beta",
+            "company": "xAI",
+            "accuracy": 63.5,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 0.81
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemini 2.5 Flash Preview (Nonthinking)",
+            "company": "Google",
+            "accuracy": 63.4,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": 0.82
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 3.1 Instruct Turbo (8B)",
+            "company": "Meta",
+            "accuracy": 63.4,
+            "cost_input": "$0.18",
+            "cost_output": "$0.18",
+            "latency": 0.92
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Grok 3 Mini Fast High Reasoning",
+            "company": "xAI",
+            "accuracy": 63.4,
+            "cost_input": "$0.60",
+            "cost_output": "$4.00",
+            "latency": 7.5
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 4 Maverick",
+            "company": "Meta",
+            "accuracy": 63.3,
+            "cost_input": "$0.27",
+            "cost_output": "$0.85",
+            "latency": 2.24
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Mistral (7B)",
+            "company": "Mistral",
+            "accuracy": 63.0,
+            "cost_input": "$0.18",
+            "cost_output": "$0.18",
+            "latency": 0.87
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 3 (8B)",
+            "company": "Meta",
+            "accuracy": 62.7,
+            "cost_input": "$0.20",
+            "cost_output": "$0.20",
+            "latency": 0.57
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Qwen 2.5 Instruct Turbo (7B)",
+            "company": "Alibaba",
+            "accuracy": 62.6,
+            "cost_input": "$0.30",
+            "cost_output": "$0.30",
+            "latency": 0.78
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "DeepSeek R1",
+            "company": "Deepseek",
+            "accuracy": 62.0,
+            "cost_input": "$8.00",
+            "cost_output": "$8.00",
+            "latency": 30.54
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Jamba 1.5 Large",
+            "company": "Ai21 Labs",
+            "accuracy": 61.9,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 3.15
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 4 Scout",
+            "company": "Meta",
+            "accuracy": 61.8,
+            "cost_input": "$0.18",
+            "cost_output": "$0.59",
+            "latency": 2.14
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "GPT 4o (2024-08-06)",
+            "company": "Openai",
+            "accuracy": 61.7,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 1.32
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "GPT 3.5",
+            "company": "Openai",
+            "accuracy": 61.6,
+            "cost_input": "$0.50",
+            "cost_output": "$1.50",
+            "latency": 1.09
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Jamba 1.6 Large",
+            "company": "Ai21 Labs",
+            "accuracy": 61.2,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 2.54
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemini 2.5 Flash Preview (Thinking)",
+            "company": "Google",
+            "accuracy": 60.6,
+            "cost_input": "$0.15",
+            "cost_output": "$3.50",
+            "latency": 5.08
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemma 2 (27B)",
+            "company": "Google",
+            "accuracy": 59.9,
+            "cost_input": "$0.50",
+            "cost_output": "$0.50",
+            "latency": 2.21
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 2 (70B)",
+            "company": "Meta",
+            "accuracy": 59.7,
+            "cost_input": "$0.90",
+            "cost_output": "$0.90",
+            "latency": 1.39
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemma 2 (9B)",
+            "company": "Google",
+            "accuracy": 59.6,
+            "cost_input": "$0.20",
+            "cost_output": "$0.20",
+            "latency": 0.91
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Grok 2",
+            "company": "xAI",
+            "accuracy": 58.0,
+            "cost_input": "$2.00",
+            "cost_output": "$10.00",
+            "latency": 1.06
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Jamba 1.5 Mini",
+            "company": "Ai21 Labs",
+            "accuracy": 56.2,
+            "cost_input": "$0.20",
+            "cost_output": "$0.40",
+            "latency": 0.52
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 2 (13B)",
+            "company": "Meta",
+            "accuracy": 55.9,
+            "cost_input": "$0.20",
+            "cost_output": "$0.20",
+            "latency": 1.47
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "GPT 4.1 Nano",
+            "company": "Openai",
+            "accuracy": 54.8,
+            "cost_input": "$0.10",
+            "cost_output": "$0.40",
+            "latency": 0.6
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "DBRX Instruct",
+            "company": "Databricks",
+            "accuracy": 48.0,
+            "cost_input": "$2.25",
+            "cost_output": "$6.75",
+            "latency": 1.26
+        },
+        {
+            "benchmark": "contract_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 2 (7B)",
+            "company": "Meta",
+            "accuracy": 42.5,
+            "cost_input": "$0.20",
+            "cost_output": "$0.20",
+            "latency": 0.8
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "o4 Mini",
+            "company": "Openai",
+            "accuracy": 66.5,
+            "cost_input": "$1.10",
+            "cost_output": "$4.40",
+            "latency": 32.84
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "o3",
+            "company": "Openai",
+            "accuracy": 63.2,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 63.95
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "Claude Opus 4 (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 63.1,
+            "cost_input": "$15.00",
+            "cost_output": "$75.00",
+            "latency": 93.54
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "Gemini 2.5 Pro Preview",
+            "company": "Google",
+            "accuracy": 61.9,
+            "cost_input": "$1.25",
+            "cost_output": "$10.00",
+            "latency": 164.66
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "o3 Mini",
+            "company": "Openai",
+            "accuracy": 59.8,
+            "cost_input": "$1.10",
+            "cost_output": "$4.40",
+            "latency": 53.8
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "DeepSeek R1",
+            "company": "Deepseek",
+            "accuracy": 58.7,
+            "cost_input": "$8.00",
+            "cost_output": "$8.00",
+            "latency": 86.07
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "Grok 3 Mini Fast High Reasoning",
+            "company": "xAI",
+            "accuracy": 57.9,
+            "cost_input": "$0.60",
+            "cost_output": "$4.00",
+            "latency": 213.66
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "Grok 3 Mini Fast Low Reasoning",
+            "company": "xAI",
+            "accuracy": 56.9,
+            "cost_input": "$0.60",
+            "cost_output": "$4.00",
+            "latency": 30.71
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "Claude Opus 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 56.4,
+            "cost_input": "$15.00",
+            "cost_output": "$75.00",
+            "latency": 14.78
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "DeepSeek V3 (03/24/2025)",
+            "company": "Deepseek",
+            "accuracy": 56.0,
+            "cost_input": "$1.20",
+            "cost_output": "$1.20",
+            "latency": 26.93
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "Claude Sonnet 4 (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 55.9,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 42.61
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "Claude 3.7 Sonnet (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 55.1,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 96.47
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "Claude Sonnet 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 53.4,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 14.06
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "Claude 3.7 Sonnet (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 52.8,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 16.23
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "GPT 4.1",
+            "company": "Openai",
+            "accuracy": 50.1,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 30.56
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "Gemini 2.5 Flash Preview (Nonthinking)",
+            "company": "Google",
+            "accuracy": 49.6,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": 16.41
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "GPT 4.1 Mini",
+            "company": "Openai",
+            "accuracy": 49.5,
+            "cost_input": "$0.40",
+            "cost_output": "$1.60",
+            "latency": 27.59
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "Grok 3 Beta",
+            "company": "xAI",
+            "accuracy": 47.3,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 5.52
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "Claude 3.5 Sonnet Latest",
+            "company": "Anthropic",
+            "accuracy": 47.1,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 11.04
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "o1",
+            "company": "Openai",
+            "accuracy": 43.6,
+            "cost_input": "$15.00",
+            "cost_output": "$60.00",
+            "latency": 92.08
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "Llama 4 Maverick",
+            "company": "Meta",
+            "accuracy": 43.1,
+            "cost_input": "$0.27",
+            "cost_output": "$0.85",
+            "latency": 9.44
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "Mistral Medium 3.1 (05/2025)",
+            "company": "Mistral",
+            "accuracy": 42.2,
+            "cost_input": "$0.40",
+            "cost_output": "$2.00",
+            "latency": 12.48
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "Gemini 2.0 Flash (001)",
+            "company": "Google",
+            "accuracy": 41.7,
+            "cost_input": "$0.10",
+            "cost_output": "$0.40",
+            "latency": 3.36
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "Claude 3.5 Haiku Latest",
+            "company": "Anthropic",
+            "accuracy": 40.0,
+            "cost_input": "$1.00",
+            "cost_output": "$5.00",
+            "latency": 10.58
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "GPT 4o (2024-11-20)",
+            "company": "Openai",
+            "accuracy": 39.7,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 4.35
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "Gemini 1.5 Pro (002)",
+            "company": "Google",
+            "accuracy": 39.7,
+            "cost_input": "$1.25",
+            "cost_output": "$5.00",
+            "latency": 3.95
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "GPT 4.1 Nano",
+            "company": "Openai",
+            "accuracy": 39.2,
+            "cost_input": "$0.10",
+            "cost_output": "$0.40",
+            "latency": 11.8
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "Gemini 2.5 Flash Preview (Thinking)",
+            "company": "Google",
+            "accuracy": 39.2,
+            "cost_input": "$0.15",
+            "cost_output": "$3.50",
+            "latency": 124.95
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "Grok 2",
+            "company": "xAI",
+            "accuracy": 37.1,
+            "cost_input": "$2.00",
+            "cost_output": "$10.00",
+            "latency": 2.38
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "Llama 4 Scout",
+            "company": "Meta",
+            "accuracy": 36.7,
+            "cost_input": "$0.18",
+            "cost_output": "$0.59",
+            "latency": 16.76
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "Mistral Large (11/2024)",
+            "company": "Mistral",
+            "accuracy": 35.2,
+            "cost_input": "$2.00",
+            "cost_output": "$6.00",
+            "latency": 5.35
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "Gemini 1.5 Flash (002)",
+            "company": "Google",
+            "accuracy": 34.9,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 2.51
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "Llama 3.3 Instruct Turbo (70B)",
+            "company": "Meta",
+            "accuracy": 34.3,
+            "cost_input": "$0.88",
+            "cost_output": "$0.88",
+            "latency": 2.95
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "Command A",
+            "company": "Cohere",
+            "accuracy": 33.0,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 11.75
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "Mistral Small 3.1 (03/2025)",
+            "company": "Mistral",
+            "accuracy": 30.3,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 4.01
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "GPT 4o Mini",
+            "company": "Openai",
+            "accuracy": 25.5,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": 7.36
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "Jamba 1.6 Large",
+            "company": "Ai21 Labs",
+            "accuracy": 21.5,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 4.84
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "Command R+",
+            "company": "Cohere",
+            "accuracy": 17.8,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 5.46
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "Mistral Small (02/2024)",
+            "company": "Mistral",
+            "accuracy": 15.3,
+            "cost_input": "$0.20",
+            "cost_output": "$0.60",
+            "latency": 5.04
+        },
+        {
+            "benchmark": "lcb-06-09-2025",
+            "benchmark_group": "Coding",
+            "model": "Jamba 1.6 Mini",
+            "company": "Ai21 Labs",
+            "accuracy": 9.8,
+            "cost_input": "$0.20",
+            "cost_output": "$0.40",
+            "latency": 1.14
+        },
+        {
+            "benchmark": "swebench-2025-06-13",
+            "benchmark_group": "Coding",
+            "model": "Claude Sonnet 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 65.0,
+            "cost_input": "$1.24",
+            "cost_output": "N/A",
+            "latency": 426.52
+        },
+        {
+            "benchmark": "swebench-2025-06-13",
+            "benchmark_group": "Coding",
+            "model": "o3",
+            "company": "Openai",
+            "accuracy": 49.8,
+            "cost_input": "$1.42",
+            "cost_output": "N/A",
+            "latency": 620.33
+        },
+        {
+            "benchmark": "swebench-2025-06-13",
+            "benchmark_group": "Coding",
+            "model": "GPT 4.1",
+            "company": "Openai",
+            "accuracy": 47.4,
+            "cost_input": "$0.45",
+            "cost_output": "N/A",
+            "latency": 173.98
+        },
+        {
+            "benchmark": "swebench-2025-06-13",
+            "benchmark_group": "Coding",
+            "model": "Gemini 2.5 Pro Preview",
+            "company": "Google",
+            "accuracy": 46.8,
+            "cost_input": "$0.88",
+            "cost_output": "N/A",
+            "latency": 540.96
+        },
+        {
+            "benchmark": "swebench-2025-06-13",
+            "benchmark_group": "Coding",
+            "model": "Gemini 2.5 Flash Preview (Nonthinking)",
+            "company": "Google",
+            "accuracy": 35.6,
+            "cost_input": "$0.11",
+            "cost_output": "N/A",
+            "latency": 251.91
+        },
+        {
+            "benchmark": "swebench-2025-06-13",
+            "benchmark_group": "Coding",
+            "model": "GPT 4.1 Mini",
+            "company": "Openai",
+            "accuracy": 34.8,
+            "cost_input": "$0.13",
+            "cost_output": "N/A",
+            "latency": 233.12
+        },
+        {
+            "benchmark": "swebench-2025-06-13",
+            "benchmark_group": "Coding",
+            "model": "o4 Mini",
+            "company": "Openai",
+            "accuracy": 33.4,
+            "cost_input": "$1.54",
+            "cost_output": "N/A",
+            "latency": 976.81
+        },
+        {
+            "benchmark": "swebench-2025-06-13",
+            "benchmark_group": "Coding",
+            "model": "GPT 4o (2024-08-06)",
+            "company": "Openai",
+            "accuracy": 27.2,
+            "cost_input": "$1.53",
+            "cost_output": "N/A",
+            "latency": 197.58
+        },
+        {
+            "benchmark": "swebench-2025-06-13",
+            "benchmark_group": "Coding",
+            "model": "Llama 4 Maverick",
+            "company": "Meta",
+            "accuracy": 18.4,
+            "cost_input": "$0.12",
+            "cost_output": "N/A",
+            "latency": 62.48
+        },
+        {
+            "benchmark": "swebench-2025-06-13",
+            "benchmark_group": "Coding",
+            "model": "Command A",
+            "company": "Cohere",
+            "accuracy": 0.2,
+            "cost_input": "$0.01",
+            "cost_output": "N/A",
+            "latency": 5.26
+        },
+        {
+            "benchmark": "finance_agent-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "o3",
+            "company": "Openai",
+            "accuracy": 48.3,
+            "cost_input": "$0.74",
+            "cost_output": "N/A",
+            "latency": 180.18
+        },
+        {
+            "benchmark": "finance_agent-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Claude Sonnet 4 (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 44.5,
+            "cost_input": "$0.85",
+            "cost_output": "N/A",
+            "latency": 136.75
+        },
+        {
+            "benchmark": "finance_agent-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Claude 3.7 Sonnet (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 44.1,
+            "cost_input": "$1.05",
+            "cost_output": "N/A",
+            "latency": 156.21
+        },
+        {
+            "benchmark": "finance_agent-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Claude Sonnet 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 43.5,
+            "cost_input": "$0.89",
+            "cost_output": "N/A",
+            "latency": 105.2
+        },
+        {
+            "benchmark": "finance_agent-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Claude 3.7 Sonnet (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 42.9,
+            "cost_input": "$0.99",
+            "cost_output": "N/A",
+            "latency": 124.6
+        },
+        {
+            "benchmark": "finance_agent-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "o4 Mini",
+            "company": "Openai",
+            "accuracy": 36.5,
+            "cost_input": "$0.28",
+            "cost_output": "N/A",
+            "latency": 162.14
+        },
+        {
+            "benchmark": "finance_agent-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Grok 3 Mini Fast High Reasoning",
+            "company": "xAI",
+            "accuracy": 31.7,
+            "cost_input": "$0.13",
+            "cost_output": "N/A",
+            "latency": 270.68
+        },
+        {
+            "benchmark": "finance_agent-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 2.5 Pro Preview",
+            "company": "Google",
+            "accuracy": 29.4,
+            "cost_input": "$0.22",
+            "cost_output": "N/A",
+            "latency": 80.21
+        },
+        {
+            "benchmark": "finance_agent-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4.1",
+            "company": "Openai",
+            "accuracy": 24.6,
+            "cost_input": "$0.24",
+            "cost_output": "N/A",
+            "latency": 66.47
+        },
+        {
+            "benchmark": "finance_agent-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Grok 3 Beta",
+            "company": "xAI",
+            "accuracy": 24.1,
+            "cost_input": "$0.44",
+            "cost_output": "N/A",
+            "latency": 64.48
+        },
+        {
+            "benchmark": "finance_agent-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4.1 Mini",
+            "company": "Openai",
+            "accuracy": 20.8,
+            "cost_input": "$0.07",
+            "cost_output": "N/A",
+            "latency": 50.11
+        },
+        {
+            "benchmark": "finance_agent-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "o1",
+            "company": "Openai",
+            "accuracy": 20.8,
+            "cost_input": "$1.44",
+            "cost_output": "N/A",
+            "latency": 421.83
+        },
+        {
+            "benchmark": "finance_agent-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4o (2024-08-06)",
+            "company": "Openai",
+            "accuracy": 19.3,
+            "cost_input": "$0.26",
+            "cost_output": "N/A",
+            "latency": 43.41
+        },
+        {
+            "benchmark": "finance_agent-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Grok 3 Mini Fast Low Reasoning",
+            "company": "xAI",
+            "accuracy": 17.1,
+            "cost_input": "$0.07",
+            "cost_output": "N/A",
+            "latency": 79.49
+        },
+        {
+            "benchmark": "finance_agent-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Claude 3.5 Haiku Latest",
+            "company": "Anthropic",
+            "accuracy": 14.3,
+            "cost_input": "$0.07",
+            "cost_output": "N/A",
+            "latency": 46.6
+        },
+        {
+            "benchmark": "finance_agent-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 2.0 Flash (001)",
+            "company": "Google",
+            "accuracy": 13.2,
+            "cost_input": "$0.01",
+            "cost_output": "N/A",
+            "latency": 26.16
+        },
+        {
+            "benchmark": "finance_agent-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "o3 Mini",
+            "company": "Openai",
+            "accuracy": 12.7,
+            "cost_input": "$0.04",
+            "cost_output": "N/A",
+            "latency": 146.86
+        },
+        {
+            "benchmark": "finance_agent-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4o Mini",
+            "company": "Openai",
+            "accuracy": 10.8,
+            "cost_input": "$0.04",
+            "cost_output": "N/A",
+            "latency": 96.03
+        },
+        {
+            "benchmark": "finance_agent-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Mistral Small 3.1 (03/2025)",
+            "company": "Mistral",
+            "accuracy": 10.0,
+            "cost_input": "$0.01",
+            "cost_output": "N/A",
+            "latency": 44.56
+        },
+        {
+            "benchmark": "finance_agent-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Command A",
+            "company": "Cohere",
+            "accuracy": 4.3,
+            "cost_input": "$0.58",
+            "cost_output": "N/A",
+            "latency": 100.95
+        },
+        {
+            "benchmark": "finance_agent-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Llama 4 Maverick",
+            "company": "Meta",
+            "accuracy": 3.6,
+            "cost_input": "$0.00",
+            "cost_output": "N/A",
+            "latency": 10.21
+        },
+        {
+            "benchmark": "finance_agent-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Llama 3.3 Instruct Turbo (70B)",
+            "company": "Meta",
+            "accuracy": 3.4,
+            "cost_input": "$0.00",
+            "cost_output": "N/A",
+            "latency": 3.5
+        },
+        {
+            "benchmark": "finance_agent-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4.1 Nano",
+            "company": "Openai",
+            "accuracy": 2.5,
+            "cost_input": "$0.00",
+            "cost_output": "N/A",
+            "latency": 63.48
+        },
+        {
+            "benchmark": "finance_agent-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Jamba 1.6 Mini",
+            "company": "Ai21 Labs",
+            "accuracy": 1.7,
+            "cost_input": "$0.04",
+            "cost_output": "N/A",
+            "latency": 36.01
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "o3",
+            "company": "Openai",
+            "accuracy": 83.6,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 65.78
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Gemini 2.5 Pro Exp",
+            "company": "Google",
+            "accuracy": 80.3,
+            "cost_input": "$1.25",
+            "cost_output": "$10.00",
+            "latency": 41.1
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Grok 3 Mini Fast High Reasoning",
+            "company": "xAI",
+            "accuracy": 79.0,
+            "cost_input": "$0.60",
+            "cost_output": "$4.00",
+            "latency": 40.62
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Claude 3.7 Sonnet (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 75.3,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 155.02
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "o3 Mini",
+            "company": "Openai",
+            "accuracy": 75.0,
+            "cost_input": "$1.10",
+            "cost_output": "$4.40",
+            "latency": 99.98
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "o4 Mini",
+            "company": "Openai",
+            "accuracy": 74.5,
+            "cost_input": "$1.10",
+            "cost_output": "$4.40",
+            "latency": 30.0
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Claude Sonnet 4 (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 74.5,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 118.46
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Grok 3 Beta",
+            "company": "xAI",
+            "accuracy": 73.7,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 29.91
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "o1",
+            "company": "Openai",
+            "accuracy": 73.0,
+            "cost_input": "$15.00",
+            "cost_output": "$60.00",
+            "latency": 40.18
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Grok 3 Mini Fast Low Reasoning",
+            "company": "xAI",
+            "accuracy": 72.7,
+            "cost_input": "$0.60",
+            "cost_output": "$4.00",
+            "latency": 14.23
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Claude Opus 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 71.7,
+            "cost_input": "$15.00",
+            "cost_output": "$75.00",
+            "latency": 19.13
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Claude Sonnet 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 69.4,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 12.82
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Llama 4 Maverick",
+            "company": "Meta",
+            "accuracy": 67.7,
+            "cost_input": "$0.27",
+            "cost_output": "$0.85",
+            "latency": 10.07
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Claude 3.7 Sonnet (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 67.4,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 9.22
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "GPT 4.1 Mini",
+            "company": "Openai",
+            "accuracy": 67.4,
+            "cost_input": "$0.40",
+            "cost_output": "$1.60",
+            "latency": 9.28
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Qwen 3 (235B)",
+            "company": "Alibaba",
+            "accuracy": 66.4,
+            "cost_input": "$0.22",
+            "cost_output": "$0.88",
+            "latency": 306.22
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Gemini 2.0 Flash (001)",
+            "company": "Google",
+            "accuracy": 65.2,
+            "cost_input": "$0.10",
+            "cost_output": "$0.40",
+            "latency": 5.8
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "GPT 4.1",
+            "company": "Openai",
+            "accuracy": 64.6,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 23.14
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "DeepSeek V3 (03/24/2025)",
+            "company": "Deepseek",
+            "accuracy": 61.1,
+            "cost_input": "$1.20",
+            "cost_output": "$1.20",
+            "latency": 23.48
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Claude 3.5 Sonnet Latest",
+            "company": "Anthropic",
+            "accuracy": 59.1,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 7.24
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Gemini 1.5 Pro (002)",
+            "company": "Google",
+            "accuracy": 58.3,
+            "cost_input": "$1.25",
+            "cost_output": "$5.00",
+            "latency": 7.71
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "DeepSeek V3",
+            "company": "Deepseek",
+            "accuracy": 54.0,
+            "cost_input": "$0.90",
+            "cost_output": "$0.90",
+            "latency": 21.28
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Gemini 2.5 Flash Preview (Nonthinking)",
+            "company": "Google",
+            "accuracy": 53.3,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": 43.45
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "GPT 4o (2024-11-20)",
+            "company": "Openai",
+            "accuracy": 53.0,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 14.92
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Mistral Small (02/2024)",
+            "company": "Mistral",
+            "accuracy": 50.8,
+            "cost_input": "$0.20",
+            "cost_output": "$0.60",
+            "latency": 7.99
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "GPT 4o (2024-05-13)",
+            "company": "Openai",
+            "accuracy": 50.3,
+            "cost_input": "$5.00",
+            "cost_output": "$15.00",
+            "latency": 10.08
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Llama 3.3 Instruct Turbo (70B)",
+            "company": "Meta",
+            "accuracy": 50.0,
+            "cost_input": "$0.88",
+            "cost_output": "$0.88",
+            "latency": 7.34
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Grok 2",
+            "company": "xAI",
+            "accuracy": 50.0,
+            "cost_input": "$2.00",
+            "cost_output": "$10.00",
+            "latency": 20.18
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Gemini 1.5 Flash (002)",
+            "company": "Google",
+            "accuracy": 46.0,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 3.39
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Mistral Large (11/2024)",
+            "company": "Mistral",
+            "accuracy": 45.2,
+            "cost_input": "$2.00",
+            "cost_output": "$6.00",
+            "latency": 15.8
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Llama 4 Scout",
+            "company": "Meta",
+            "accuracy": 44.4,
+            "cost_input": "$0.18",
+            "cost_output": "$0.59",
+            "latency": 12.09
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "GPT 4o Mini",
+            "company": "Openai",
+            "accuracy": 44.2,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": 15.32
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Mistral Small 3.1 (03/2025)",
+            "company": "Mistral",
+            "accuracy": 41.4,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 8.82
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "GPT 4.1 Nano",
+            "company": "Openai",
+            "accuracy": 39.9,
+            "cost_input": "$0.10",
+            "cost_output": "$0.40",
+            "latency": 4.19
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Claude 3.5 Haiku Latest",
+            "company": "Anthropic",
+            "accuracy": 37.9,
+            "cost_input": "$1.00",
+            "cost_output": "$5.00",
+            "latency": 6.56
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "GPT 3.5",
+            "company": "Openai",
+            "accuracy": 29.3,
+            "cost_input": "$0.50",
+            "cost_output": "$1.50",
+            "latency": 2.63
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Command A",
+            "company": "Cohere",
+            "accuracy": 29.3,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 11.49
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Command R+",
+            "company": "Cohere",
+            "accuracy": 29.0,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 8.19
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Jamba 1.6 Large",
+            "company": "Ai21 Labs",
+            "accuracy": 24.2,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 15.47
+        },
+        {
+            "benchmark": "gpqa-05-30-2025",
+            "benchmark_group": "Academic",
+            "model": "Jamba 1.6 Mini",
+            "company": "Ai21 Labs",
+            "accuracy": 20.5,
+            "cost_input": "$0.20",
+            "cost_output": "$0.40",
+            "latency": 4.95
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "o1",
+            "company": "Openai",
+            "accuracy": 96.5,
+            "cost_input": "$15.00",
+            "cost_output": "$60.00",
+            "latency": 11.15
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "o3",
+            "company": "Openai",
+            "accuracy": 96.1,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 8.51
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "o4 Mini",
+            "company": "Openai",
+            "accuracy": 96.0,
+            "cost_input": "$1.10",
+            "cost_output": "$4.40",
+            "latency": 6.6
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "o3 Mini",
+            "company": "Openai",
+            "accuracy": 94.8,
+            "cost_input": "$1.10",
+            "cost_output": "$4.40",
+            "latency": 8.39
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Gemini 2.5 Pro Exp",
+            "company": "Google",
+            "accuracy": 93.1,
+            "cost_input": "$1.25",
+            "cost_output": "$10.00",
+            "latency": 10.7
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "o1 Preview",
+            "company": "Openai",
+            "accuracy": 93.0,
+            "cost_input": "$15.00",
+            "cost_output": "$60.00",
+            "latency": 16.44
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Claude Opus 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 92.9,
+            "cost_input": "$15.00",
+            "cost_output": "$75.00",
+            "latency": 11.93
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Claude Sonnet 4 (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 92.7,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 26.99
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Grok 2",
+            "company": "xAI",
+            "accuracy": 92.3,
+            "cost_input": "$2.00",
+            "cost_output": "$10.00",
+            "latency": 4.09
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "GPT 4.1",
+            "company": "Openai",
+            "accuracy": 91.2,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 3.08
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Gemini 2.5 Flash Preview (Thinking)",
+            "company": "Google",
+            "accuracy": 91.0,
+            "cost_input": "$0.15",
+            "cost_output": "$3.50",
+            "latency": 8.87
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "DeepSeek R1",
+            "company": "Deepseek",
+            "accuracy": 90.8,
+            "cost_input": "$8.00",
+            "cost_output": "$8.00",
+            "latency": 41.57
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Qwen 3 (235B)",
+            "company": "Alibaba",
+            "accuracy": 90.6,
+            "cost_input": "$0.22",
+            "cost_output": "$0.88",
+            "latency": 26.26
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Claude Sonnet 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 90.3,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 8.71
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "o1 Mini",
+            "company": "Openai",
+            "accuracy": 90.2,
+            "cost_input": "$3.00",
+            "cost_output": "$12.00",
+            "latency": 5.89
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Claude 3.7 Sonnet (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 90.2,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 15.74
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Grok 3 Mini Fast High Reasoning",
+            "company": "xAI",
+            "accuracy": 90.1,
+            "cost_input": "$0.60",
+            "cost_output": "$4.00",
+            "latency": 7.06
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Grok 3 Mini Fast Low Reasoning",
+            "company": "xAI",
+            "accuracy": 88.6,
+            "cost_input": "$0.60",
+            "cost_output": "$4.00",
+            "latency": 4.88
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Llama 3.1 Instruct Turbo (405B)",
+            "company": "Meta",
+            "accuracy": 88.2,
+            "cost_input": "$3.50",
+            "cost_output": "$3.50",
+            "latency": 8.75
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "GPT 4o (2024-08-06)",
+            "company": "Openai",
+            "accuracy": 88.2,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 3.39
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Gemini 2.5 Flash Preview (Nonthinking)",
+            "company": "Google",
+            "accuracy": 86.7,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": 2.25
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Llama 3.1 Instruct Turbo (70B)",
+            "company": "Meta",
+            "accuracy": 84.8,
+            "cost_input": "$0.88",
+            "cost_output": "$0.88",
+            "latency": 4.8
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "GPT 4.1 Mini",
+            "company": "Openai",
+            "accuracy": 84.6,
+            "cost_input": "$0.40",
+            "cost_output": "$1.60",
+            "latency": 1.86
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Grok 3 Beta",
+            "company": "xAI",
+            "accuracy": 83.9,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 7.54
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Claude 3.5 Sonnet Latest",
+            "company": "Anthropic",
+            "accuracy": 83.2,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 5.92
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "DeepSeek V3 (03/24/2025)",
+            "company": "Deepseek",
+            "accuracy": 82.0,
+            "cost_input": "$1.20",
+            "cost_output": "$1.20",
+            "latency": 12.88
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "GPT 4 Turbo",
+            "company": "Openai",
+            "accuracy": 82.0,
+            "cost_input": "$10.00",
+            "cost_output": "$30.00",
+            "latency": 8.41
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "DeepSeek V3",
+            "company": "Deepseek",
+            "accuracy": 80.9,
+            "cost_input": "$0.90",
+            "cost_output": "$0.90",
+            "latency": 6.82
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Command A",
+            "company": "Cohere",
+            "accuracy": 80.5,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 2.91
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Mistral Medium 3.1 (05/2025)",
+            "company": "Mistral",
+            "accuracy": 78.2,
+            "cost_input": "$0.40",
+            "cost_output": "$2.00",
+            "latency": 7.34
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Qwen 2.5 Instruct Turbo (72B)",
+            "company": "Alibaba",
+            "accuracy": 77.4,
+            "cost_input": "$1.20",
+            "cost_output": "$1.20",
+            "latency": 5.57
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Gemini 1.5 Pro (002)",
+            "company": "Google",
+            "accuracy": 76.5,
+            "cost_input": "$1.25",
+            "cost_output": "$5.00",
+            "latency": 5.93
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Mistral Large (11/2024)",
+            "company": "Mistral",
+            "accuracy": 76.2,
+            "cost_input": "$2.00",
+            "cost_output": "$6.00",
+            "latency": 4.86
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "GPT 4o Mini",
+            "company": "Openai",
+            "accuracy": 72.4,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": 2.32
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Mistral Small 3.1 (03/2025)",
+            "company": "Mistral",
+            "accuracy": 69.1,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 3.63
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "GPT 4.1 Nano",
+            "company": "Openai",
+            "accuracy": 68.2,
+            "cost_input": "$0.10",
+            "cost_output": "$0.40",
+            "latency": 1.42
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Jamba 1.5 Large",
+            "company": "Ai21 Labs",
+            "accuracy": 68.1,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 6.0
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Llama 3.1 Instruct Turbo (8B)",
+            "company": "Meta",
+            "accuracy": 62.6,
+            "cost_input": "$0.18",
+            "cost_output": "$0.18",
+            "latency": 2.37
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "GPT 3.5",
+            "company": "Openai",
+            "accuracy": 58.5,
+            "cost_input": "$0.50",
+            "cost_output": "$1.50",
+            "latency": 1.59
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Mistral Small (02/2024)",
+            "company": "Mistral",
+            "accuracy": 57.0,
+            "cost_input": "$0.20",
+            "cost_output": "$0.60",
+            "latency": 2.76
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Jamba 1.5 Mini",
+            "company": "Ai21 Labs",
+            "accuracy": 55.2,
+            "cost_input": "$0.20",
+            "cost_output": "$0.40",
+            "latency": 1.14
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Mixtral (8x7B)",
+            "company": "Mistral",
+            "accuracy": 53.2,
+            "cost_input": "$0.60",
+            "cost_output": "$0.60",
+            "latency": 3.49
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Jamba 1.6 Mini",
+            "company": "Ai21 Labs",
+            "accuracy": 52.5,
+            "cost_input": "$0.20",
+            "cost_output": "$0.40",
+            "latency": 2.19
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Command R+",
+            "company": "Cohere",
+            "accuracy": 51.4,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 6.06
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Llama 4 Scout",
+            "company": "Meta",
+            "accuracy": 50.9,
+            "cost_input": "$0.18",
+            "cost_output": "$0.59",
+            "latency": 4.8
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Jamba 1.6 Large",
+            "company": "Ai21 Labs",
+            "accuracy": 50.7,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 7.31
+        },
+        {
+            "benchmark": "medqa-05-30-2025",
+            "benchmark_group": "Healthcare",
+            "model": "Llama 4 Maverick",
+            "company": "Meta",
+            "accuracy": 43.3,
+            "cost_input": "$0.27",
+            "cost_output": "$0.85",
+            "latency": 7.75
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Grok 3 Beta",
+            "company": "xAI",
+            "accuracy": 88.1,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 3.91
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "DeepSeek V3 (03/24/2025)",
+            "company": "Deepseek",
+            "accuracy": 86.2,
+            "cost_input": "$1.20",
+            "cost_output": "$1.20",
+            "latency": 13.66
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemini 2.5 Pro Exp",
+            "company": "Google",
+            "accuracy": 86.1,
+            "cost_input": "$1.25",
+            "cost_output": "$10.00",
+            "latency": 8.05
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "GPT 4.1",
+            "company": "Openai",
+            "accuracy": 85.8,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 3.82
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude Sonnet 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 85.2,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 8.03
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude 3.5 Sonnet Latest",
+            "company": "Anthropic",
+            "accuracy": 84.9,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 4.51
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Mistral Medium 3.1 (05/2025)",
+            "company": "Mistral",
+            "accuracy": 84.9,
+            "cost_input": "$0.40",
+            "cost_output": "$2.00",
+            "latency": 4.58
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude 3.7 Sonnet (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 84.8,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 13.13
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "DeepSeek V3",
+            "company": "Deepseek",
+            "accuracy": 84.5,
+            "cost_input": "$0.90",
+            "cost_output": "$0.90",
+            "latency": 8.72
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemini 2.0 Pro Exp",
+            "company": "Google",
+            "accuracy": 84.5,
+            "cost_input": "$1.25",
+            "cost_output": "$5.00",
+            "latency": 2.21
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "GPT 4.1 Mini",
+            "company": "Openai",
+            "accuracy": 84.3,
+            "cost_input": "$0.40",
+            "cost_output": "$1.60",
+            "latency": 2.55
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude Sonnet 4 (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 84.3,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 13.14
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Qwen 3 (235B)",
+            "company": "Alibaba",
+            "accuracy": 84.0,
+            "cost_input": "$0.22",
+            "cost_output": "$0.88",
+            "latency": 17.23
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude 3.5 Haiku Latest",
+            "company": "Anthropic",
+            "accuracy": 83.8,
+            "cost_input": "$1.00",
+            "cost_output": "$5.00",
+            "latency": 5.29
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Grok 3 Mini Fast High Reasoning",
+            "company": "xAI",
+            "accuracy": 83.6,
+            "cost_input": "$0.60",
+            "cost_output": "$4.00",
+            "latency": 6.27
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Grok 3 Mini Fast Low Reasoning",
+            "company": "xAI",
+            "accuracy": 83.4,
+            "cost_input": "$0.60",
+            "cost_output": "$4.00",
+            "latency": 4.98
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "GPT 4o (2024-08-06)",
+            "company": "Openai",
+            "accuracy": 83.3,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 4.27
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "GPT 4o (2024-11-20)",
+            "company": "Openai",
+            "accuracy": 82.9,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 3.14
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "o3",
+            "company": "Openai",
+            "accuracy": 82.8,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 10.04
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemini 2.5 Flash Preview (Thinking)",
+            "company": "Google",
+            "accuracy": 82.5,
+            "cost_input": "$0.15",
+            "cost_output": "$3.50",
+            "latency": 5.07
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "o1",
+            "company": "Openai",
+            "accuracy": 81.9,
+            "cost_input": "$15.00",
+            "cost_output": "$60.00",
+            "latency": 22.26
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude Opus 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 81.5,
+            "cost_input": "$15.00",
+            "cost_output": "$75.00",
+            "latency": 11.93
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemini 2.5 Flash Preview (Nonthinking)",
+            "company": "Google",
+            "accuracy": 81.5,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": 1.56
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude 3 Opus",
+            "company": "Anthropic",
+            "accuracy": 81.3,
+            "cost_input": "$15.00",
+            "cost_output": "$75.00",
+            "latency": 10.73
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "o4 Mini",
+            "company": "Openai",
+            "accuracy": 81.1,
+            "cost_input": "$1.10",
+            "cost_output": "$4.40",
+            "latency": 7.91
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "DeepSeek R1",
+            "company": "Deepseek",
+            "accuracy": 81.0,
+            "cost_input": "$8.00",
+            "cost_output": "$8.00",
+            "latency": 51.02
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude 3.7 Sonnet (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 80.7,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 5.78
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 3.1 Instruct Turbo (8B)",
+            "company": "Meta",
+            "accuracy": 80.3,
+            "cost_input": "$0.18",
+            "cost_output": "$0.18",
+            "latency": 2.32
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Command A",
+            "company": "Cohere",
+            "accuracy": 79.7,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 5.5
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "o1 Preview",
+            "company": "Openai",
+            "accuracy": 78.6,
+            "cost_input": "$15.00",
+            "cost_output": "$60.00",
+            "latency": 3.96
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Grok 2",
+            "company": "xAI",
+            "accuracy": 78.6,
+            "cost_input": "$2.00",
+            "cost_output": "$10.00",
+            "latency": 3.96
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "o3 Mini",
+            "company": "Openai",
+            "accuracy": 78.5,
+            "cost_input": "$1.10",
+            "cost_output": "$4.40",
+            "latency": 15.35
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude 3 Sonnet",
+            "company": "Anthropic",
+            "accuracy": 78.5,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 6.13
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "GPT 4 Turbo",
+            "company": "Openai",
+            "accuracy": 77.9,
+            "cost_input": "$10.00",
+            "cost_output": "$30.00",
+            "latency": 8.55
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "o1 Mini",
+            "company": "Openai",
+            "accuracy": 77.8,
+            "cost_input": "$3.00",
+            "cost_output": "$12.00",
+            "latency": 6.36
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 3.1 Instruct Turbo (70B)",
+            "company": "Meta",
+            "accuracy": 77.1,
+            "cost_input": "$0.88",
+            "cost_output": "$0.88",
+            "latency": 6.41
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Mixtral Instruct (8x22B)",
+            "company": "Mistral",
+            "accuracy": 76.8,
+            "cost_input": "$1.20",
+            "cost_output": "$1.20",
+            "latency": 6.45
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Mistral Small 3.1 (03/2025)",
+            "company": "Mistral",
+            "accuracy": 76.7,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 2.83
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 3.3 Instruct Turbo (70B)",
+            "company": "Meta",
+            "accuracy": 76.6,
+            "cost_input": "$0.88",
+            "cost_output": "$0.88",
+            "latency": 32.1
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 4 Maverick",
+            "company": "Meta",
+            "accuracy": 76.1,
+            "cost_input": "$0.27",
+            "cost_output": "$0.85",
+            "latency": 2.17
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "GPT 4.1 Nano",
+            "company": "Openai",
+            "accuracy": 75.5,
+            "cost_input": "$0.10",
+            "cost_output": "$0.40",
+            "latency": 1.43
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Jamba 1.6 Mini",
+            "company": "Ai21 Labs",
+            "accuracy": 75.3,
+            "cost_input": "$0.20",
+            "cost_output": "$0.40",
+            "latency": 2.27
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Mistral Large (11/2024)",
+            "company": "Mistral",
+            "accuracy": 75.1,
+            "cost_input": "$2.00",
+            "cost_output": "$6.00",
+            "latency": 4.78
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Llama 4 Scout",
+            "company": "Meta",
+            "accuracy": 74.4,
+            "cost_input": "$0.18",
+            "cost_output": "$0.59",
+            "latency": 3.07
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemini 2.0 Flash Thinking Exp",
+            "company": "Google",
+            "accuracy": 74.2,
+            "cost_input": "$0.10",
+            "cost_output": "$0.70",
+            "latency": 2.09
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemini 2.0 Flash (001)",
+            "company": "Google",
+            "accuracy": 73.7,
+            "cost_input": "$0.10",
+            "cost_output": "$0.40",
+            "latency": 1.14
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Mistral Small (02/2024)",
+            "company": "Mistral",
+            "accuracy": 73.5,
+            "cost_input": "$0.20",
+            "cost_output": "$0.60",
+            "latency": 3.97
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Command R",
+            "company": "Cohere",
+            "accuracy": 72.3,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": 3.35
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Jamba 1.6 Large",
+            "company": "Ai21 Labs",
+            "accuracy": 71.8,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 8.7
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "GPT 4o Mini",
+            "company": "Openai",
+            "accuracy": 70.8,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": 4.29
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemini 1.5 Pro (001)",
+            "company": "Google",
+            "accuracy": 67.6,
+            "cost_input": "$1.25",
+            "cost_output": "$5.00",
+            "latency": 4.53
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemini 1.5 Pro (002)",
+            "company": "Google",
+            "accuracy": 67.6,
+            "cost_input": "$1.25",
+            "cost_output": "$5.00",
+            "latency": 4.53
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Command R+",
+            "company": "Cohere",
+            "accuracy": 66.9,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 6.05
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Qwen 2.5 Instruct Turbo (72B)",
+            "company": "Alibaba",
+            "accuracy": 63.2,
+            "cost_input": "$1.20",
+            "cost_output": "$1.20",
+            "latency": 2.82
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemini 1.5 Flash (002)",
+            "company": "Google",
+            "accuracy": 62.8,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 2.05
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Jamba 1.5 Large",
+            "company": "Ai21 Labs",
+            "accuracy": 60.1,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 5.19
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "GPT 3.5",
+            "company": "Openai",
+            "accuracy": 58.4,
+            "cost_input": "$0.50",
+            "cost_output": "$1.50",
+            "latency": 2.13
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Qwen 2.5 Instruct Turbo (7B)",
+            "company": "Alibaba",
+            "accuracy": 58.4,
+            "cost_input": "$0.30",
+            "cost_output": "$0.30",
+            "latency": 1.43
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Gemini 1.0 Pro 002",
+            "company": "Google",
+            "accuracy": 58.1,
+            "cost_input": "$0.50",
+            "cost_output": "$1.50",
+            "latency": 5.79
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Claude 3.5 Sonnet",
+            "company": "Anthropic",
+            "accuracy": 53.9,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 1.88
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Jamba 1.5 Mini",
+            "company": "Ai21 Labs",
+            "accuracy": 53.0,
+            "cost_input": "$0.20",
+            "cost_output": "$0.40",
+            "latency": 1.24
+        },
+        {
+            "benchmark": "case_law-05-30-2025",
+            "benchmark_group": "Legal",
+            "model": "Mistral (7B)",
+            "company": "Mistral",
+            "accuracy": 40.0,
+            "cost_input": "$0.18",
+            "cost_output": "$0.18",
+            "latency": 4.33
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4.1",
+            "company": "Openai",
+            "accuracy": 71.2,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 10.33
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "o3",
+            "company": "Openai",
+            "accuracy": 71.0,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 19.13
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "o4 Mini",
+            "company": "Openai",
+            "accuracy": 70.1,
+            "cost_input": "$1.10",
+            "cost_output": "$4.40",
+            "latency": 17.5
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Grok 3 Beta",
+            "company": "xAI",
+            "accuracy": 69.1,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 23.86
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Grok 3 Mini Fast High Reasoning",
+            "company": "xAI",
+            "accuracy": 68.6,
+            "cost_input": "$0.60",
+            "cost_output": "$4.00",
+            "latency": 14.12
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 2.5 Pro Exp",
+            "company": "Google",
+            "accuracy": 68.4,
+            "cost_input": "$1.25",
+            "cost_output": "$10.00",
+            "latency": 17.99
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Claude 3.7 Sonnet (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 68.0,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 22.33
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Claude Sonnet 4 (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 67.3,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 227.37
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Grok 3 Mini Fast Low Reasoning",
+            "company": "xAI",
+            "accuracy": 66.0,
+            "cost_input": "$0.60",
+            "cost_output": "$4.00",
+            "latency": 10.42
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4.1 Mini",
+            "company": "Openai",
+            "accuracy": 65.8,
+            "cost_input": "$0.40",
+            "cost_output": "$1.60",
+            "latency": 6.56
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "DeepSeek R1",
+            "company": "Deepseek",
+            "accuracy": 63.2,
+            "cost_input": "$8.00",
+            "cost_output": "$8.00",
+            "latency": 46.8
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 2.5 Flash Preview (Nonthinking)",
+            "company": "Google",
+            "accuracy": 62.6,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": 8.67
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "DeepSeek V3 (03/24/2025)",
+            "company": "Deepseek",
+            "accuracy": 60.9,
+            "cost_input": "$1.20",
+            "cost_output": "$1.20",
+            "latency": 36.59
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "DeepSeek V3",
+            "company": "Deepseek",
+            "accuracy": 60.7,
+            "cost_input": "$0.90",
+            "cost_output": "$0.90",
+            "latency": 28.88
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Claude 3.5 Sonnet Latest",
+            "company": "Anthropic",
+            "accuracy": 60.5,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": null
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Claude Sonnet 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 59.9,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 162.67
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Claude 3.5 Haiku Latest",
+            "company": "Anthropic",
+            "accuracy": 58.2,
+            "cost_input": "$1.00",
+            "cost_output": "$5.00",
+            "latency": null
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Grok 2",
+            "company": "xAI",
+            "accuracy": 58.2,
+            "cost_input": "$2.00",
+            "cost_output": "$10.00",
+            "latency": 84.8
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Mistral Medium 3.1 (05/2025)",
+            "company": "Mistral",
+            "accuracy": 58.1,
+            "cost_input": "$0.40",
+            "cost_output": "$2.00",
+            "latency": 30.56
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Llama 4 Maverick",
+            "company": "Meta",
+            "accuracy": 57.6,
+            "cost_input": "$0.27",
+            "cost_output": "$0.85",
+            "latency": 6.59
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4o (2024-11-20)",
+            "company": "Openai",
+            "accuracy": 56.6,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 6.35
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "o3 Mini",
+            "company": "Openai",
+            "accuracy": 55.7,
+            "cost_input": "$1.10",
+            "cost_output": "$4.40",
+            "latency": 31.42
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4o Mini",
+            "company": "Openai",
+            "accuracy": 55.0,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": null
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Command A",
+            "company": "Cohere",
+            "accuracy": 54.5,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 14.34
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Llama 4 Scout",
+            "company": "Meta",
+            "accuracy": 53.9,
+            "cost_input": "$0.18",
+            "cost_output": "$0.59",
+            "latency": 9.22
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Mistral Small 3.1 (03/2025)",
+            "company": "Mistral",
+            "accuracy": 53.2,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 12.25
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 2.0 Pro Exp",
+            "company": "Google",
+            "accuracy": 53.1,
+            "cost_input": "$1.25",
+            "cost_output": "$5.00",
+            "latency": 18.13
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4.1 Nano",
+            "company": "Openai",
+            "accuracy": 52.4,
+            "cost_input": "$0.10",
+            "cost_output": "$0.40",
+            "latency": 12.47
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Jamba 1.6 Large",
+            "company": "Ai21 Labs",
+            "accuracy": 50.7,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 29.61
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 1.5 Pro (002)",
+            "company": "Google",
+            "accuracy": 50.3,
+            "cost_input": "$1.25",
+            "cost_output": "$5.00",
+            "latency": 37.35
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4o (2024-08-06)",
+            "company": "Openai",
+            "accuracy": 49.3,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": null
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Llama 3.1 Instruct Turbo (70B)",
+            "company": "Meta",
+            "accuracy": 47.2,
+            "cost_input": "$0.88",
+            "cost_output": "$0.88",
+            "latency": null
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Jamba 1.5 Large",
+            "company": "Ai21 Labs",
+            "accuracy": 46.6,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 10.74
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 1.5 Flash (002)",
+            "company": "Google",
+            "accuracy": 46.6,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 28.38
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Jamba 1.6 Mini",
+            "company": "Ai21 Labs",
+            "accuracy": 46.0,
+            "cost_input": "$0.20",
+            "cost_output": "$0.40",
+            "latency": 4.28
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Llama 3.1 Instruct Turbo (8B)",
+            "company": "Meta",
+            "accuracy": 43.5,
+            "cost_input": "$0.18",
+            "cost_output": "$0.18",
+            "latency": null
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Jamba 1.5 Mini",
+            "company": "Ai21 Labs",
+            "accuracy": 39.9,
+            "cost_input": "$0.20",
+            "cost_output": "$0.40",
+            "latency": 2.34
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 2.0 Flash (001)",
+            "company": "Google",
+            "accuracy": 38.5,
+            "cost_input": "$0.10",
+            "cost_output": "$0.40",
+            "latency": 31.35
+        },
+        {
+            "benchmark": "corp_fin_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 1.5 Flash (001)",
+            "company": "Google",
+            "accuracy": 32.9,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": null
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Claude 3.7 Sonnet (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 80.6,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 5.67
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Claude 3.7 Sonnet (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 79.2,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 13.58
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4.1",
+            "company": "Openai",
+            "accuracy": 79.0,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 5.03
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 2.5 Pro Exp",
+            "company": "Google",
+            "accuracy": 78.8,
+            "cost_input": "$1.25",
+            "cost_output": "$10.00",
+            "latency": 8.91
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "o3",
+            "company": "Openai",
+            "accuracy": 78.4,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 21.22
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Claude 3.5 Sonnet Latest",
+            "company": "Anthropic",
+            "accuracy": 78.1,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 4.22
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4.1 Mini",
+            "company": "Openai",
+            "accuracy": 77.7,
+            "cost_input": "$0.40",
+            "cost_output": "$1.60",
+            "latency": 4.6
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "o4 Mini",
+            "company": "Openai",
+            "accuracy": 77.1,
+            "cost_input": "$1.10",
+            "cost_output": "$4.40",
+            "latency": 13.0
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4o (2024-08-06)",
+            "company": "Openai",
+            "accuracy": 75.2,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 7.36
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Mistral Small 3.1 (03/2025)",
+            "company": "Mistral",
+            "accuracy": 75.0,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 8.31
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Claude Sonnet 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 74.6,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 8.42
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Llama 4 Maverick",
+            "company": "Meta",
+            "accuracy": 72.7,
+            "cost_input": "$0.27",
+            "cost_output": "$0.85",
+            "latency": 2.72
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 2.0 Flash (001)",
+            "company": "Google",
+            "accuracy": 72.6,
+            "cost_input": "$0.10",
+            "cost_output": "$0.40",
+            "latency": 3.79
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4o (2024-11-20)",
+            "company": "Openai",
+            "accuracy": 72.1,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 5.98
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Llama 4 Scout",
+            "company": "Meta",
+            "accuracy": 71.7,
+            "cost_input": "$0.18",
+            "cost_output": "$0.59",
+            "latency": 2.43
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 1.5 Pro (002)",
+            "company": "Google",
+            "accuracy": 71.0,
+            "cost_input": "$1.25",
+            "cost_output": "$5.00",
+            "latency": 4.2
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 2.5 Flash Preview (Nonthinking)",
+            "company": "Google",
+            "accuracy": 70.9,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": 3.56
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Claude Opus 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 70.9,
+            "cost_input": "$15.00",
+            "cost_output": "$75.00",
+            "latency": 13.76
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 2.5 Flash Preview (Thinking)",
+            "company": "Google",
+            "accuracy": 69.5,
+            "cost_input": "$0.15",
+            "cost_output": "$3.50",
+            "latency": 8.4
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4o Mini",
+            "company": "Openai",
+            "accuracy": 69.2,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": 6.06
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4.1 Nano",
+            "company": "Openai",
+            "accuracy": 67.0,
+            "cost_input": "$0.10",
+            "cost_output": "$0.40",
+            "latency": 3.86
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Nova Lite",
+            "company": "Amazon",
+            "accuracy": 66.1,
+            "cost_input": "$0.06",
+            "cost_output": "$0.24",
+            "latency": null
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Nova Pro",
+            "company": "Amazon",
+            "accuracy": 63.7,
+            "cost_input": "$0.80",
+            "cost_output": "$3.20",
+            "latency": null
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Claude Sonnet 4 (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 62.5,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 46.32
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Mistral Medium 3.1 (05/2025)",
+            "company": "Mistral",
+            "accuracy": 60.5,
+            "cost_input": "$0.40",
+            "cost_output": "$2.00",
+            "latency": 7.14
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Llama 3.2 Vision (90B)",
+            "company": "Meta",
+            "accuracy": 55.0,
+            "cost_input": "$1.20",
+            "cost_output": "$1.20",
+            "latency": 5.07
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 1.5 Flash (002)",
+            "company": "Google",
+            "accuracy": 54.6,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 2.1
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Llama 3.2 Vision (11B)",
+            "company": "Meta",
+            "accuracy": 38.8,
+            "cost_input": "$0.18",
+            "cost_output": "$0.18",
+            "latency": 2.45
+        },
+        {
+            "benchmark": "mortgage_tax-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Grok 2 Vision",
+            "company": "xAI",
+            "accuracy": 26.7,
+            "cost_input": "$2.00",
+            "cost_output": "$10.00",
+            "latency": null
+        },
+        {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "Claude Opus 4 (Nonthinking)",
             "company": "Anthropic",
             "accuracy": 93.8,
@@ -4674,6 +6023,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "o4 Mini",
             "company": "Openai",
             "accuracy": 93.4,
@@ -4683,6 +6033,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "Claude Sonnet 4 (Nonthinking)",
             "company": "Anthropic",
             "accuracy": 92.9,
@@ -4692,6 +6043,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "Claude 3.7 Sonnet (Thinking)",
             "company": "Anthropic",
             "accuracy": 92.8,
@@ -4701,6 +6053,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "Qwen 3 (235B)",
             "company": "Alibaba",
             "accuracy": 92.7,
@@ -4710,6 +6063,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "Claude 3.5 Sonnet Latest",
             "company": "Anthropic",
             "accuracy": 92.5,
@@ -4719,6 +6073,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "DeepSeek V3",
             "company": "Deepseek",
             "accuracy": 92.5,
@@ -4728,6 +6083,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "Llama 4 Maverick",
             "company": "Meta",
             "accuracy": 92.5,
@@ -4737,6 +6093,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "DeepSeek R1",
             "company": "Deepseek",
             "accuracy": 92.4,
@@ -4746,6 +6103,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "Claude 3.7 Sonnet (Nonthinking)",
             "company": "Anthropic",
             "accuracy": 92.4,
@@ -4755,6 +6113,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "Gemini 2.5 Pro Exp",
             "company": "Google",
             "accuracy": 92.2,
@@ -4764,6 +6123,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "DeepSeek V3 (03/24/2025)",
             "company": "Deepseek",
             "accuracy": 92.0,
@@ -4773,6 +6133,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "Mistral Medium 3.1 (05/2025)",
             "company": "Mistral",
             "accuracy": 91.6,
@@ -4782,6 +6143,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "o3 Mini",
             "company": "Openai",
             "accuracy": 91.6,
@@ -4791,6 +6153,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "o3",
             "company": "Openai",
             "accuracy": 91.4,
@@ -4800,6 +6163,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "Grok 3 Beta",
             "company": "xAI",
             "accuracy": 91.3,
@@ -4809,6 +6173,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "Llama 3.3 Instruct Turbo (70B)",
             "company": "Meta",
             "accuracy": 91.3,
@@ -4818,6 +6183,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "Claude Sonnet 4 (Thinking)",
             "company": "Anthropic",
             "accuracy": 90.6,
@@ -4827,6 +6193,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "GPT 4o (2024-08-06)",
             "company": "Openai",
             "accuracy": 90.6,
@@ -4836,6 +6203,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "Grok 3 Mini Fast Low Reasoning",
             "company": "xAI",
             "accuracy": 90.3,
@@ -4845,6 +6213,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "Grok 3 Mini Fast High Reasoning",
             "company": "xAI",
             "accuracy": 90.3,
@@ -4854,6 +6223,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "GPT 4o (2024-11-20)",
             "company": "Openai",
             "accuracy": 90.2,
@@ -4863,6 +6233,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "Gemini 2.5 Flash Preview (Thinking)",
             "company": "Google",
             "accuracy": 90.0,
@@ -4872,6 +6243,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "Gemini 2.5 Flash Preview (Nonthinking)",
             "company": "Google",
             "accuracy": 89.8,
@@ -4881,6 +6253,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "Gemini 1.5 Pro (002)",
             "company": "Google",
             "accuracy": 89.3,
@@ -4890,6 +6263,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "o1",
             "company": "Openai",
             "accuracy": 88.9,
@@ -4899,6 +6273,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "Gemini 2.0 Flash (001)",
             "company": "Google",
             "accuracy": 88.9,
@@ -4908,6 +6283,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "Mistral Large (11/2024)",
             "company": "Mistral",
             "accuracy": 88.2,
@@ -4917,6 +6293,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "GPT 4.1 Mini",
             "company": "Openai",
             "accuracy": 87.9,
@@ -4926,6 +6303,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "Llama 4 Scout",
             "company": "Meta",
             "accuracy": 87.8,
@@ -4935,6 +6313,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "GPT 4.1",
             "company": "Openai",
             "accuracy": 87.2,
@@ -4944,6 +6323,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "Command A",
             "company": "Cohere",
             "accuracy": 86.8,
@@ -4953,6 +6333,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "Gemini 1.5 Flash (002)",
             "company": "Google",
             "accuracy": 86.7,
@@ -4962,6 +6343,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "Grok 2",
             "company": "xAI",
             "accuracy": 86.3,
@@ -4971,6 +6353,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "GPT 4o Mini",
             "company": "Openai",
             "accuracy": 86.2,
@@ -4980,6 +6363,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "Claude 3.5 Haiku Latest",
             "company": "Anthropic",
             "accuracy": 85.9,
@@ -4989,6 +6373,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "Mistral Small 3.1 (03/2025)",
             "company": "Mistral",
             "accuracy": 85.4,
@@ -4998,6 +6383,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "Mistral Small (02/2024)",
             "company": "Mistral",
             "accuracy": 85.0,
@@ -5007,6 +6393,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "Jamba 1.5 Large",
             "company": "Ai21 Labs",
             "accuracy": 77.4,
@@ -5016,6 +6403,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "Jamba 1.6 Large",
             "company": "Ai21 Labs",
             "accuracy": 75.0,
@@ -5025,6 +6413,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "GPT 4.1 Nano",
             "company": "Openai",
             "accuracy": 69.8,
@@ -5034,6 +6423,7 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "Jamba 1.6 Mini",
             "company": "Ai21 Labs",
             "accuracy": 44.7,
@@ -5043,12 +6433,503 @@
         },
         {
             "benchmark": "mgsm-2025-05-30",
+            "benchmark_group": "Math",
             "model": "Jamba 1.5 Mini",
             "company": "Ai21 Labs",
             "accuracy": 29.6,
             "cost_input": "$0.20",
             "cost_output": "$0.40",
             "latency": 2.99
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "o3",
+            "company": "Openai",
+            "accuracy": 79.0,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 25.18
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Grok 3 Beta",
+            "company": "xAI",
+            "accuracy": 78.8,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 13.11
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "o4 Mini",
+            "company": "Openai",
+            "accuracy": 78.8,
+            "cost_input": "$1.10",
+            "cost_output": "$4.40",
+            "latency": 15.25
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "o1",
+            "company": "Openai",
+            "accuracy": 78.6,
+            "cost_input": "$15.00",
+            "cost_output": "$60.00",
+            "latency": 19.19
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Claude 3.7 Sonnet (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 78.4,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 43.26
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4.1",
+            "company": "Openai",
+            "accuracy": 78.4,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 8.03
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4o (2024-11-20)",
+            "company": "Openai",
+            "accuracy": 78.1,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 5.83
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 2.5 Pro Exp",
+            "company": "Google",
+            "accuracy": 77.1,
+            "cost_input": "$1.25",
+            "cost_output": "$10.00",
+            "latency": 22.04
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "DeepSeek R1",
+            "company": "Deepseek",
+            "accuracy": 76.7,
+            "cost_input": "$8.00",
+            "cost_output": "$8.00",
+            "latency": 162.88
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Grok 3 Mini Fast Low Reasoning",
+            "company": "xAI",
+            "accuracy": 76.5,
+            "cost_input": "$0.60",
+            "cost_output": "$4.00",
+            "latency": 11.74
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Claude Sonnet 4 (Thinking)",
+            "company": "Anthropic",
+            "accuracy": 75.9,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 31.99
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Claude 3.7 Sonnet (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 75.9,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 6.44
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Claude Opus 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 75.8,
+            "cost_input": "$15.00",
+            "cost_output": "$75.00",
+            "latency": 15.32
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Grok 3 Mini Fast High Reasoning",
+            "company": "xAI",
+            "accuracy": 75.7,
+            "cost_input": "$0.60",
+            "cost_output": "$4.00",
+            "latency": 24.96
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 2.5 Flash Preview (Nonthinking)",
+            "company": "Google",
+            "accuracy": 75.4,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": 5.46
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "DeepSeek V3 (03/24/2025)",
+            "company": "Deepseek",
+            "accuracy": 75.2,
+            "cost_input": "$1.20",
+            "cost_output": "$1.20",
+            "latency": 31.71
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4.1 Mini",
+            "company": "Openai",
+            "accuracy": 75.0,
+            "cost_input": "$0.40",
+            "cost_output": "$1.60",
+            "latency": 5.91
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4o (2024-08-06)",
+            "company": "Openai",
+            "accuracy": 75.0,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 9.54
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 2.5 Flash Preview (Thinking)",
+            "company": "Google",
+            "accuracy": 74.7,
+            "cost_input": "$0.15",
+            "cost_output": "$3.50",
+            "latency": 15.37
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Qwen 3 (235B)",
+            "company": "Alibaba",
+            "accuracy": 74.4,
+            "cost_input": "$0.22",
+            "cost_output": "$0.88",
+            "latency": 94.33
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "o3 Mini",
+            "company": "Openai",
+            "accuracy": 73.9,
+            "cost_input": "$1.10",
+            "cost_output": "$4.40",
+            "latency": 81.08
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 2.0 Flash Thinking Exp",
+            "company": "Google",
+            "accuracy": 73.8,
+            "cost_input": "$0.10",
+            "cost_output": "$0.70",
+            "latency": 12.8
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Claude 3.5 Sonnet Latest",
+            "company": "Anthropic",
+            "accuracy": 73.7,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 5.94
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Claude Sonnet 4 (Nonthinking)",
+            "company": "Anthropic",
+            "accuracy": 73.5,
+            "cost_input": "$3.00",
+            "cost_output": "$15.00",
+            "latency": 12.18
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Mistral Medium 3.1 (05/2025)",
+            "company": "Mistral",
+            "accuracy": 73.4,
+            "cost_input": "$0.40",
+            "cost_output": "$2.00",
+            "latency": 11.27
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 2.0 Flash Exp",
+            "company": "Google",
+            "accuracy": 72.4,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 7.51
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "DeepSeek V3",
+            "company": "Deepseek",
+            "accuracy": 72.0,
+            "cost_input": "$0.90",
+            "cost_output": "$0.90",
+            "latency": 25.76
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Grok 2",
+            "company": "xAI",
+            "accuracy": 71.4,
+            "cost_input": "$2.00",
+            "cost_output": "$10.00",
+            "latency": 10.63
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 2.0 Pro Exp",
+            "company": "Google",
+            "accuracy": 71.0,
+            "cost_input": "$1.25",
+            "cost_output": "$5.00",
+            "latency": 9.14
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 2.0 Flash (001)",
+            "company": "Google",
+            "accuracy": 70.5,
+            "cost_input": "$0.10",
+            "cost_output": "$0.40",
+            "latency": 5.72
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Llama 4 Maverick",
+            "company": "Meta",
+            "accuracy": 69.3,
+            "cost_input": "$0.27",
+            "cost_output": "$0.85",
+            "latency": 28.18
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Mistral Large (11/2024)",
+            "company": "Mistral",
+            "accuracy": 67.7,
+            "cost_input": "$2.00",
+            "cost_output": "$6.00",
+            "latency": 12.0
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Command A",
+            "company": "Cohere",
+            "accuracy": 66.6,
+            "cost_input": "$2.50",
+            "cost_output": "$10.00",
+            "latency": 10.13
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Llama 3.1 Instruct Turbo (405B)",
+            "company": "Meta",
+            "accuracy": 66.3,
+            "cost_input": "$3.50",
+            "cost_output": "$3.50",
+            "latency": 24.91
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4.1 Nano",
+            "company": "Openai",
+            "accuracy": 66.1,
+            "cost_input": "$0.10",
+            "cost_output": "$0.40",
+            "latency": 3.04
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Jamba 1.6 Large",
+            "company": "Ai21 Labs",
+            "accuracy": 65.3,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 16.3
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "GPT 4o Mini",
+            "company": "Openai",
+            "accuracy": 64.9,
+            "cost_input": "$0.15",
+            "cost_output": "$0.60",
+            "latency": 9.0
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 1.5 Pro (002)",
+            "company": "Google",
+            "accuracy": 64.9,
+            "cost_input": "$1.25",
+            "cost_output": "$5.00",
+            "latency": 9.91
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Llama 3.3 Instruct Turbo (70B)",
+            "company": "Meta",
+            "accuracy": 63.9,
+            "cost_input": "$0.88",
+            "cost_output": "$0.88",
+            "latency": 3.86
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Claude 3.5 Haiku Latest",
+            "company": "Anthropic",
+            "accuracy": 63.0,
+            "cost_input": "$1.00",
+            "cost_output": "$5.00",
+            "latency": 5.0
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Mistral Small 3.1 (03/2025)",
+            "company": "Mistral",
+            "accuracy": 62.9,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 7.95
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Jamba 1.5 Large",
+            "company": "Ai21 Labs",
+            "accuracy": 62.7,
+            "cost_input": "$2.00",
+            "cost_output": "$8.00",
+            "latency": 20.32
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Llama 3.1 Instruct Turbo (70B)",
+            "company": "Meta",
+            "accuracy": 61.1,
+            "cost_input": "$0.88",
+            "cost_output": "$0.88",
+            "latency": 4.39
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Llama 4 Scout",
+            "company": "Meta",
+            "accuracy": 59.0,
+            "cost_input": "$0.18",
+            "cost_output": "$0.59",
+            "latency": 7.09
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Mistral Small (02/2024)",
+            "company": "Mistral",
+            "accuracy": 54.1,
+            "cost_input": "$0.20",
+            "cost_output": "$0.60",
+            "latency": 8.97
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Gemini 1.5 Flash (002)",
+            "company": "Google",
+            "accuracy": 53.4,
+            "cost_input": "$0.07",
+            "cost_output": "$0.30",
+            "latency": 3.74
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Jamba 1.6 Mini",
+            "company": "Ai21 Labs",
+            "accuracy": 50.3,
+            "cost_input": "$0.20",
+            "cost_output": "$0.40",
+            "latency": 4.39
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Jamba 1.5 Mini",
+            "company": "Ai21 Labs",
+            "accuracy": 46.9,
+            "cost_input": "$0.20",
+            "cost_output": "$0.40",
+            "latency": 4.82
+        },
+        {
+            "benchmark": "tax_eval_v2-05-30-2025",
+            "benchmark_group": "Finance",
+            "model": "Llama 3.1 Instruct Turbo (8B)",
+            "company": "Meta",
+            "accuracy": 39.0,
+            "cost_input": "$0.18",
+            "cost_output": "$0.18",
+            "latency": 2.45
         }
     ]
 }

--- a/vals_parser.py
+++ b/vals_parser.py
@@ -122,6 +122,32 @@ for benchmark_url_full in list_benchmark_links:
 
         print(f"  Found {len(model_entries)} model entries on {benchmark_id}.")
 
+        # --- Extract Benchmark Group ---
+        benchmark_group = "N/A" # Default value
+        try:
+            # Find the p tag with "Task Type:" text
+            task_type_p = benchmark_soup.find('p', text='Task Type:')
+            if task_type_p:
+                # Get the parent div of the "Task Type:" p tag
+                task_type_container = task_type_p.parent
+                if task_type_container:
+                    # Find the astro-island within this container
+                    astro_island = task_type_container.find('astro-island')
+                    if astro_island:
+                        # Find the first button inside the astro-island
+                        first_button = astro_island.find('button')
+                        if first_button:
+                            # Find the p tag with the specific class inside the first button
+                            # This class is 'text-zinc-900 text-sm tracking-0.2'
+                            group_p_tag = first_button.find('p', class_='text-zinc-900 text-sm tracking-0.2')
+                            if group_p_tag:
+                                benchmark_group = group_p_tag.text.strip()
+        except Exception as e:
+            print(f"  Error extracting benchmark group on {benchmark_url_full}: {e}")
+            
+        print(f"  Benchmark Group: {benchmark_group}") # Add this print for verification
+        print(f"  Benchmark ID: {benchmark_id}") # Keep this print
+
         # Loop through each individual model entry link
         for model_link in model_entries:
             try:
@@ -194,6 +220,7 @@ for benchmark_url_full in list_benchmark_links:
                         # Create a dictionary for the current model's data
                         model_data = {
                             'benchmark': benchmark_id, # Include the benchmark identifier for context
+                            'benchmark_group': benchmark_group, # Add the extracted group here                            
                             'model': model_name,
                             'company': company_name,
                             'accuracy': accuracy,

--- a/vals_parser.py
+++ b/vals_parser.py
@@ -1,226 +1,231 @@
-import requests # Used for making HTTP requests to fetch web pages
-from bs4 import BeautifulSoup # Used for parsing HTML content
-import json # Used for saving the extracted data into a JSON file
-import re # Used for regular expressions, specifically for cleaning the accuracy value
-from datetime import datetime # Used for adding a timestamp to the output data
-from selenium import webdriver
-from selenium.webdriver.chrome.service import Service
-import time
-from selenium.webdriver.common.by import By
+import requests # Library for making HTTP requests
+from bs4 import BeautifulSoup # Library for parsing HTML content
+import json # Library for working with JSON data
+import re # Library for using regular expressions
+from datetime import datetime # Library for getting current date and time
+from selenium import webdriver # Library for browser automation
+from selenium.webdriver.chrome.service import Service # Service class for Chrome driver
+import time # Library for time-related functions (like pauses)
+from selenium.webdriver.common.by import By # Class for locating elements by strategy
 
 # --- Configuration ---
-site_base_url = 'https://www.vals.ai' # Base URL of the website
-url_main_benchmarks_page = site_base_url + '/benchmarks' # URL of the main benchmarks listing page
-chromedriver_path = '/opt/chromedriver-linux64/chromedriver'
+site_base_url = 'https://www.vals.ai' # Base URL of the target website
+url_main_benchmarks_page = site_base_url + '/benchmarks' # URL for the main benchmarks listing
+chromedriver_path = '/opt/chromedriver-linux64/chromedriver' # Path to the Chrome WebDriver executable
+
+# Initialize Selenium WebDriver service
 chrome_service = Service(executable_path=chromedriver_path)
+# Initialize WebDriver instance
 driver = webdriver.Chrome(service=chrome_service)
 
 # --- Access Main Benchmarks Page ---
-# Attempt to fetch the content of the main benchmarks page
+# Fetch the HTML content of the main benchmarks page using requests
 try:
     response = requests.get(url_main_benchmarks_page)
-    response.raise_for_status() # Check for bad status codes (400s or 500s) and raise an exception
-    html_content_main_page = response.text # Get the HTML content as text
+    # Raise an exception for bad status codes (4xx or 5xx)
+    response.raise_for_status()
+    # Get the page content as text
+    html_content_main_page = response.text
+# Handle potential request errors (network issues, bad URL, etc.)
 except requests.exceptions.RequestException as e:
-    # If there's an error accessing the page, print the error and exit
     print(f"Error accessing the main page: {e}")
-    exit()
+    exit() # Exit the script if the main page cannot be accessed
 
 # --- Parse Main Page and Collect Benchmark Links ---
-# Parse the HTML content of the main page using BeautifulSoup
+# Parse the HTML content using BeautifulSoup
 soup_main_page = BeautifulSoup(html_content_main_page, 'html.parser')
 
-# Set to store unique benchmark URLs
+# Use a set to store unique benchmark URLs found on the main page
 benchmark_links = set()
 
-# Find all <a> tags with an href attribute on the main page
+# Find all anchor tags (<a>) with an href attribute
 all_links_on_main_page = soup_main_page.find_all('a', href=True)
 
-# Iterate through all found links
+# Iterate through each found link
 for link in all_links_on_main_page:
-    href = link['href'] # Get the value of the href attribute
+    href = link['href'] # Get the link's URL
 
-    # Check if the href is a relative path starting with '/benchmarks/'
-    # and is not the main benchmarks page itself
+    # Check if the link is a relative path pointing to a specific benchmark page
     if href and href.startswith('/benchmarks/') and href.strip('/') != 'benchmarks':
-        full_url = site_base_url + href # Construct the absolute URL
+        # Construct the full absolute URL
+        full_url = site_base_url + href
         benchmark_links.add(full_url) # Add the full URL to the set
 
-    # Also check for absolute links starting with the main page URL prefix
-    # This handles cases where links might already be absolute
+    # Also check for absolute links that start with the main benchmarks URL prefix
     elif href and href.startswith(url_main_benchmarks_page + '/') and href.strip('/') != url_main_benchmarks_page.strip('/'):
         benchmark_links.add(href) # Add the absolute URL to the set
 
-# Convert the set of links to a list
+# Convert the set of unique links to a list for ordered processing
 list_benchmark_links = list(benchmark_links)
 
-# Print the collected benchmark links
+# Print the total number of unique benchmark links found
 print(f"Found {len(list_benchmark_links)} benchmark links:")
+# Print each collected link
 for link in list_benchmark_links:
     print(link)
 
 print("-" * 20)
 
 # --- Data Extraction from Individual Benchmark Pages ---
-# List to store all extracted model data from all benchmarks
+# List to store extracted data for all models across all benchmarks
 all_benchmark_data = []
 
 # Loop through each collected benchmark URL
 for benchmark_url_full in list_benchmark_links:
     print(f"\nProcessing benchmark page: {benchmark_url_full}")
 
-    # Attempt to fetch the content of the current benchmark page
+    # Use Selenium to access the page to handle potential dynamic content loading
     try:
         driver.get(benchmark_url_full)
-        time.sleep(3)
+        time.sleep(3) # Wait for the page to load dynamic content
+
+        # Attempt to click the 'Accuracy' sort button if present
         try:
             accuracy_sort_btn= driver.find_element(By.XPATH, '//button[contains(text(), "Accuracy")]')
             accuracy_sort_btn.click()
-            time.sleep(1)
+            time.sleep(1) # Short pause after clicking
         except:
+            # If button not found, print a warning and continue without sorting
             print("Accuracy sort button not found, continuing without sorting.")
+
+        # Attempt to click the 'See More' button if present to load all entries
         try:
             see_more_btn = driver.find_element(By.XPATH, '//button[starts-with(text(), "See ")]')
             see_more_btn.click()
-            time.sleep(1) 
+            time.sleep(1) # Short pause after clicking
         except:
-            pass        
-        response = requests.get(benchmark_url_full)
-        response.raise_for_status() # Check for bad status codes
-        benchmark_html = driver.page_source
-    except requests.exceptions.RequestException as e:
-        # If error, print error and skip to the next URL
-        print(f"Error accessing {benchmark_url_full}: {e}")
-        continue
+            # If button not found, it might not exist or all entries are already visible
+            pass
 
-    # Parse the HTML content of the benchmark page
+        # Get the page source *after* potential dynamic content loading by Selenium
+        benchmark_html = driver.page_source
+        # Note: The original requests.get call here is redundant after using Selenium
+        # response = requests.get(benchmark_url_full)
+        # response.raise_for_status() # Check for bad status codes - This won't reflect dynamic content
+        # benchmark_html = response.text # This gets the initial HTML, not post-JS rendering
+
+    # Handle potential errors during page access with Selenium
+    except Exception as e: # Catching a general exception for Selenium/page loading issues
+        print(f"Error accessing {benchmark_url_full} with Selenium: {e}")
+        continue # Skip to the next URL if the current page fails to load
+
+    # Parse the dynamically loaded HTML content using BeautifulSoup
     benchmark_soup = BeautifulSoup(benchmark_html, 'html.parser')
 
-    # Extract the benchmark identifier from the URL (e.g., 'legal-qa')
+    # Extract the unique identifier for the current benchmark from the URL
     benchmark_id = benchmark_url_full.split('/')[-1]
-    if not benchmark_id: # Handle potential trailing slash in the URL
+    if not benchmark_id: # Handle cases with trailing slashes
         benchmark_id = benchmark_url_full.split('/')[-2]
-    # print(f"  Benchmark ID: {benchmark_id}") # Commented out to avoid double print
 
-    # List to hold data for models found on the current page
+    # List to hold data for models found on the current benchmark page
     models_on_this_page = []
 
-    # Find the main HTML element that contains the list of model entries.
-    # Based on inspection, each model entry is an <a> tag with class 'block',
-    # and these <a> tags are direct children of a <div>. We find the container
-    # by locating the first model <a> tag and getting its parent.
+    # Find the HTML container element that holds the list of model entries.
+    # This is typically the parent of the first model entry link.
     first_model_link = benchmark_soup.find('a', class_='block')
-
     model_entries_container = None
     if first_model_link:
-        model_entries_container = first_model_link.parent # The parent div containing all model links
+        model_entries_container = first_model_link.parent
 
-    # If the container is found
+    # If the container element is found
     if model_entries_container:
-        # Find all individual model entry <a> tags within the container
+        # Find all individual model entry links (<a> tags) within the container
         model_entries = model_entries_container.find_all('a', class_='block')
 
         print(f"  Found {len(model_entries)} model entries on {benchmark_id}.")
 
-        # --- Extract Benchmark Group ---
-        benchmark_group = "N/A" # Default value
+        # --- Extract Benchmark Group (Task Type) ---
+        benchmark_group = "N/A" # Default value if not found
         try:
-            # Find the p tag with "Task Type:" text
+            # Locate the element containing the 'Task Type:' label
             task_type_p = benchmark_soup.find('p', text='Task Type:')
             if task_type_p:
-                # Get the parent div of the "Task Type:" p tag
+                # Navigate up to the container holding the label and the value
                 task_type_container = task_type_p.parent
                 if task_type_container:
-                    # Find the astro-island within this container
-                    astro_island = task_type_container.find('astro-island')
-                    if astro_island:
-                        # Find the first button inside the astro-island
-                        first_button = astro_island.find('button')
-                        if first_button:
-                            # Find the p tag with the specific class inside the first button
-                            # This class is 'text-zinc-900 text-sm tracking-0.2'
-                            group_p_tag = first_button.find('p', class_='text-zinc-900 text-sm tracking-0.2')
-                            if group_p_tag:
-                                benchmark_group = group_p_tag.text.strip()
+                    # Find the specific element containing the group name (based on structure inspection)
+                    group_p_tag = task_type_container.find('p', class_='text-zinc-900 text-sm tracking-0.2')
+                    if group_p_tag:
+                        benchmark_group = group_p_tag.text.strip() # Extract and clean the text
         except Exception as e:
+            # Handle potential errors during group extraction
             print(f"  Error extracting benchmark group on {benchmark_url_full}: {e}")
-            
-        print(f"  Benchmark Group: {benchmark_group}") # Add this print for verification
-        print(f"  Benchmark ID: {benchmark_id}") # Keep this print
 
-        # Loop through each individual model entry link
+        # Print extracted benchmark details
+        print(f"  Benchmark Group: {benchmark_group}")
+        print(f"  Benchmark ID: {benchmark_id}")
+
+        # Loop through each individual model entry element found
         for model_link in model_entries:
             try:
-                # Find the <div> within the <a> tag that holds the structured data for the model row
-                # Using the specific class name identified from HTML inspection
+                # Find the div that structures the data for a single model row
                 data_div = model_link.find('div', class_='grid grid-cols-[2.5fr_1fr_1fr_1fr] py-3 bg-white border-b border-zinc-700 hover:bg-zinc-100 transition-all duration-150')
 
-                # If the data div is found
+                # If the data structure div is found
                 if data_div:
-                    # The data (Accuracy, Costs, Latency) are in direct <p> tags following the first <div>.
-                    # The first <div> contains the Rank, Company Logo, and Model Name.
-                    # Find the first column <div> that contains logo and model name
+                    # Find the first column div containing the company logo and model name
                     col1_div = data_div.find('div', class_='flex flex-row gap-2 pl-3')
 
-                    # Find all direct child <p> tags within the data_div (these hold Accuracy, Costs, Latency)
+                    # Find all direct paragraph tags (<p>) within the data_div (contain Accuracy, Costs, Latency)
                     p_tags = data_div.find_all('p', recursive=False)
 
-                    # Ensure we found the necessary elements before attempting extraction
+                    # Proceed only if the essential elements are found
                     if col1_div and len(p_tags) >= 3:
-                        # Extract Company Name from the src attribute of the <img> tag in the first column div
+                        # Extract Company Name from the image source within the first column
                         company_img_tag = col1_div.find('img')
-                        company_name = 'N/A' # Default value
+                        company_name = 'N/A'
                         if company_img_tag and company_img_tag.get('src'):
                             img_src = company_img_tag['src']
-                            # Extract the filename from the source path (e.g., 'OpenAI.svg' from '/Icons/OpenAI.svg')
+                            # Extract and format the company name from the image filename
                             filename = img_src.split('/')[-1]
-                            # Extract the company name from the filename (e.g., 'OpenAI' from 'OpenAI.svg')
                             company_name = filename.split('.')[0] if '.' in filename else filename
-                            # Clean up the name and format it (e.g., 'xAI' from 'xAI', 'Meta' from 'Meta-Llama')
                             company_name = company_name.replace('-Instruct', '').replace('-', ' ').strip().title()
-                            if company_name.lower() == 'xai': # Correct capitalization for xAI
+                            if company_name.lower() == 'xai':
                                 company_name = 'xAI'
 
-                        # Extract the Model Name from the specific <p> tag in the first column div
+                        # Extract the Model Name from its specific paragraph tag within the first column
                         model_name_tag = col1_div.find('p', class_='text-slate900 text-xs md:text-xs lg:text-sm gap-1 flex-row items-center justify-center tracking-0.2')
-                        model_name = model_name_tag.text.strip() if model_name_tag else 'N/A' # Extract text or use default
+                        model_name = model_name_tag.text.strip() if model_name_tag else 'N/A'
 
-
-                        # Extract Accuracy from the first direct <p> tag
+                        # Extract Accuracy from the first data paragraph tag
                         accuracy_tag = p_tags[0]
                         accuracy_text = accuracy_tag.get_text(strip=True) if accuracy_tag else ''
-                        # Use regex to find the percentage value, which is more reliable than just stripping text
+                        # Use regex to find and extract the percentage value
                         accuracy_match = re.search(r'\d+\.?\d*%', accuracy_text)
-                        accuracy = accuracy_match.group(0) if accuracy_match else accuracy_text # Use regex match or full text
-                        accuracy_number_string = accuracy.replace('%', '')
+                        accuracy_str = accuracy_match.group(0) if accuracy_match else accuracy_text
+                        accuracy_number_string = accuracy_str.replace('%', '')
+                        # Convert the extracted number string to a float
                         try:
                             accuracy = float(accuracy_number_string)
                         except ValueError:
-                            print(f"Warning: Could not convert '{accuracy_number_string}' to a number.")
-                            accuracy = None                       
+                            # Handle cases where conversion fails
+                            print(f"Warning: Could not convert '{accuracy_number_string}' to a number for accuracy.")
+                            accuracy = None
 
-                        # Extract Costs (Input/Output) from the second direct <p> tag
+                        # Extract Costs (Input/Output) from the second data paragraph tag
                         costs_tag = p_tags[1]
                         costs_text = costs_tag.text.strip() if costs_tag else 'N/A / N/A'
-                        # Split the text by '/' to separate input and output costs
+                        # Split the text to separate input and output costs
                         cost_parts = costs_text.split('/')
                         cost_input = cost_parts[0].strip() if len(cost_parts) > 0 else 'N/A'
                         cost_output = cost_parts[1].strip() if len(cost_parts) > 1 else 'N/A'
 
-                        # Extract Latency from the third direct <p> tag
+                        # Extract Latency from the third data paragraph tag
                         latency_tag = p_tags[2]
-                        latency = latency_tag.text.strip() if latency_tag else 'N/A' # Extract text or use default
-                        latency_number_string = latency.replace(' s', '')
+                        latency_text = latency_tag.text.strip() if latency_tag else 'N/A'
+                        latency_number_string = latency_text.replace(' s', '')
+                         # Convert the extracted number string to a float
                         try:
                             latency = float(latency_number_string)
                         except ValueError:
-                            print(f"Warning: Could not convert '{latency_number_string}' to a number.")
-                            latency = None   
+                            # Handle cases where conversion fails
+                            print(f"Warning: Could not convert '{latency_number_string}' to a number for latency.")
+                            latency = None
 
-                        # Create a dictionary for the current model's data
+                        # Compile the extracted data into a dictionary for the current model
                         model_data = {
-                            'benchmark': benchmark_id, # Include the benchmark identifier for context
-                            'benchmark_group': benchmark_group, # Add the extracted group here                            
+                            'benchmark': benchmark_id,
+                            'benchmark_group': benchmark_group,
                             'model': model_name,
                             'company': company_name,
                             'accuracy': accuracy,
@@ -231,20 +236,14 @@ for benchmark_url_full in list_benchmark_links:
                         # Add the model's data to the list for this page
                         models_on_this_page.append(model_data)
 
-                    # Optional: Print a warning if the expected structure isn't found for a model row
-                    # else:
-                    #      print(f"    Warning: Could not find expected structure within data_div for a model entry on {benchmark_url_full}")
-
-
+            # Catch any errors that occur during the processing of a single model entry
             except Exception as e:
-                # Catch any errors during the parsing of a single model entry
                 print(f"    Error parsing model entry on {benchmark_url_full}: {e}")
-                # Continue to the next model entry even if one fails
+                # Continue processing other model entries even if one fails
 
     # If the container for model entries was not found on the page
     else:
         print(f"  Could not find the model entries container on {benchmark_url_full}")
-
 
     # Add all collected model data from the current page to the main list
     all_benchmark_data.extend(models_on_this_page)
@@ -253,7 +252,7 @@ for benchmark_url_full in list_benchmark_links:
 print("\nFinished processing all benchmark pages.")
 print(f"Collected data for {len(all_benchmark_data)} model entries in total.")
 
-# Prepare the final data structure including a timestamp
+# Prepare the final data structure including a timestamp for when the data was collected
 data_with_timestamp = {
     'timestamp_utc': datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S'), # Add current UTC timestamp
     'benchmarks': all_benchmark_data # Include the list of all extracted model data
@@ -262,16 +261,18 @@ data_with_timestamp = {
 # Define the output JSON filename
 json_filename = 'benchmarks_data.json'
 
-# Attempt to write the data to the JSON file
+# Attempt to write the collected data to a JSON file
 try:
     with open(json_filename, 'w', encoding='utf-8') as f:
-        # Dump the Python dictionary to a JSON file, ensuring non-ASCII chars are handled
-        # and formatting with indentation for readability
+        # Write the dictionary to a JSON file, ensuring proper encoding and formatting
         json.dump(data_with_timestamp, f, ensure_ascii=False, indent=4)
     print(f"Successfully saved data to {json_filename}")
+# Handle potential file writing errors
 except IOError as e:
-    # If there's an error writing the file, print the error
     print(f"Error saving data to {json_filename}: {e}")
 
 print("-" * 20)
 print("Script finished.")
+
+# Close the Selenium browser instance
+driver.quit()


### PR DESCRIPTION
Fetch the benchmarks categorized into groups, the same way they are in the original source (vals.ai).